### PR TITLE
ci: ensure copier-template-extensions is installed for template updates

### DIFF
--- a/project/.github/workflows/template-update.yml.jinja
+++ b/project/.github/workflows/template-update.yml.jinja
@@ -23,7 +23,7 @@ jobs:
           echo "before=$before" >> "$GITHUB_OUTPUT"
 
       - name: Refresh from template
-        run: uvx copier update --trust --defaults .
+        run: uvx --with=copier-template-extensions copier update --trust --defaults .
 
       - name: Capture template version (after)
         id: template-version-after


### PR DESCRIPTION
## Summary
- update the template refresh workflow to install `copier-template-extensions` when running `uvx copier update`

## Testing
- not run (workflow-only change)
