### PR TITLE
fix: guard init tasks on copier updates

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -12,12 +12,18 @@ _jinja_extensions:
   - extensions.py:GitExtension
   - extensions.py:SlugifyExtension
 _tasks:
-  - command: uv python pin 3.14
-  - command: uv sync
-  - command: git init -b main
-  - command: git add .
-  - command: 'git commit -m "chore: initial commit"'
-  - command: |
+  - when: "{{ not '.git' | path_exists }}"
+    command: uv python pin 3.14
+  - when: "{{ not '.git' | path_exists }}"
+    command: uv sync
+  - when: "{{ not '.git' | path_exists }}"
+    command: git init -b main
+  - when: "{{ not '.git' | path_exists }}"
+    command: git add .
+  - when: "{{ not '.git' | path_exists }}"
+    command: 'git commit -m "chore: initial commit"'
+  - when: "{{ not '.git' | path_exists }}"
+    command: |
       if command -v gh >/dev/null 2>&1 && [ "{{ gh_repo_create | default('skip') }}" != "skip" ]; then
         visibility="--private"
         if [ "{{ gh_repo_create | default('skip') }}" = "public" ]; then

--- a/extensions.py
+++ b/extensions.py
@@ -7,6 +7,7 @@ import urllib.error
 import urllib.request
 import unicodedata
 from datetime import date
+from pathlib import Path
 
 from jinja2.ext import Extension
 
@@ -50,6 +51,12 @@ def slugify(value, separator="-"):
     return re.sub(r"[-_\s]+", separator, value).strip("-_")
 
 
+def path_exists(path: str) -> bool:
+    """Return True when ``path`` exists relative to the destination."""
+
+    return Path(path).expanduser().exists()
+
+
 def pypi_distribution_exists(name: str) -> bool:
     """Return True if a distribution with ``name`` is present on PyPI.
 
@@ -91,6 +98,7 @@ class GitExtension(Extension):
         environment.filters["git_user_email"] = git_user_email
         environment.filters["gh_user_login"] = gh_user_login
         environment.filters["command_available"] = command_available
+        environment.filters["path_exists"] = path_exists
 
 
 class SlugifyExtension(Extension):

--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -23,6 +23,7 @@ Description: {{ project_description }}
    - Walrus operator
    - Enums subclasses
 - Dependency changes use `uv add` or `uv remove`
+- Use `uv run python - <<'PY' ...` instead `python - <<'PY'` for inline scripts
 - Docstrings in Markdown ("myst") format, expressing intentions rather than implementation details.
   Make references to other code if appropriate. Eg: "See also `{py:func}`other_module.helper_function`.".
 - Explicit and robust type annotations using built-in generics (`list`, `dict`, etc.), union types with `|`, etc.


### PR DESCRIPTION
## Summary
- add `path_exists` Jinja filter and use it to run bootstrap tasks only when no `.git` directory is present

## Testing
- not run (network restricted)
