### PR TITLE
docs: prefer `uv run` for inline scripts

### DIFF
--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -23,6 +23,7 @@ Description: {{ project_description }}
    - Walrus operator
    - Enums subclasses
 - Dependency changes use `uv add` or `uv remove`
+- Use `uv run python - <<'PY' ...` instead `python - <<'PY'` for inline scripts
 - Docstrings in Markdown ("myst") format, expressing intentions rather than implementation details.
   Make references to other code if appropriate. Eg: "See also `{py:func}`other_module.helper_function`.".
 - Explicit and robust type annotations using built-in generics (`list`, `dict`, etc.), union types with `|`, etc.


### PR DESCRIPTION
## Summary
- document using `uv run python - <<'PY' ...` instead of bare `python - <<'PY'` in agent instructions

## Testing
- not run (docs-only change)
