### PR TITLE
chore: bump ty to 0.0.2

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -104,7 +104,7 @@ test = [
 lint = ["ruff"]
 qa = [
     { include-group = "lint" },
-    "ty>=0.0.1a34",
+    "ty>=0.0.2",
 ]
 docs = [
     "myst-parser>=3.0.0",


### PR DESCRIPTION
## Summary
- raise the QA dependency `ty` to `>=0.0.2` in the template `pyproject.toml`

## Testing
- not run (config-only change)
