### PR TITLE
feat: allow destination path in template CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Please read [my blog post](https://mgaitan.github.io/en/posts/opinionated-python
 Quick shortcut (auto-detects copy vs update):
 
 ```bash
-uvx git+https://github.com/mgaitan/python-package-copier-template
+uvx git+https://github.com/mgaitan/python-package-copier-template [DESTINATION]
 ```
 
-This runs `copier copy --trust --defaults` when no `.copier-answers.yml` is present, or `copier update --trust --defaults` when it is.
+This runs `copier copy --trust --defaults` to `DESTINATION` (or `.` if omitted) when no `.copier-answers.yml` is present, or `copier update --trust --defaults` when it is.
 Check the installed version with `uvx git+https://github.com/mgaitan/python-package-copier-template -- --version`.
 
 Start a new project explicitly with Copier:

--- a/python_package_copier_template/cli.py
+++ b/python_package_copier_template/cli.py
@@ -22,7 +22,15 @@ def has_answers(dst: Path) -> bool:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="python-package-copier-template",
-        description="Apply the template via Copier (copy if no answers file, update otherwise).",
+        description=(
+            "Apply the template via Copier. If the destination has a .copier-answers file, run update; "
+            "otherwise run copy."
+        ),
+    )
+    parser.add_argument(
+        "destination",
+        nargs="?",
+        help="Destination directory (defaults to current working directory).",
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {get_version()}")
     return parser
@@ -30,9 +38,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
 
-    dst = Path.cwd()
+    dst = Path(args.destination).expanduser() if args.destination else Path.cwd()
 
     if has_answers(dst):
         run_update(dst_path=str(dst), defaults=True, trust=True)


### PR DESCRIPTION
## Summary
- CLI now accepts an optional `destination` argument; if provided, copy/update runs in that path, otherwise in `.`
- Update README to document `[DESTINATION]` usage with the shortcut command

## Testing
- not run
