### PR TITLE
Bump ty minimum version to 0.0.19

### DIFF
--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -104,7 +104,7 @@ test = [
 lint = ["ruff"]
 qa = [
     { include-group = "lint" },
-    "ty>=0.0.2",
+    "ty>=0.0.19",
 ]
 docs = [
     "myst-parser>=3.0.0",


### PR DESCRIPTION
Updates template QA dependency to require ty >=0.0.19.\n\nCloses #16.