### PR TITLE
Add uv dependency cooldown default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Demo repo generated from this template: [mgaitan/yet-another-demo](https://githu
 
 - 🐍 Modern Python package (3.12+)
 - 📦 Build and dependency management with [uv](https://docs.astral.sh/uv/), split by groups (dev/qa/docs)
-- 🧊 Dependency cooldowns enabled by default in `uv` (`[tool.uv].exclude-newer = "1 week"`) to reduce supply-chain risk
+- 🧊 Dependency cooldowns enabled by default in `uv` (`[tool.uv].exclude-newer = "1 week"`), with targeted overrides when needed (for example `ty`) to reduce supply-chain risk without blocking QA tools
 - 🧹 Linting and formatting via [Ruff](https://docs.astral.sh/ruff/) with a broad set of rules enabled
 - ✅ Type checking via [ty](https://github.com/astral-sh/ty)
 - 🧪 Tests with [pytest](https://docs.pytest.org/en/stable/), [coverage.py](https://coverage.readthedocs.io/en/latest/) and extensions

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -28,7 +28,7 @@ uv tool install {{ python_package_distribution_name }}
 ## Development
 
 - Install dependencies with `uv sync`.
-- New dependency releases are delayed by one week via `uv` cooldown (`[tool.uv].exclude-newer = "1 week"`).
+- New dependency releases are delayed by one week via `uv` cooldown (`[tool.uv].exclude-newer = "1 week"`), with per-package overrides when required (for example, `ty`).
 - Run the QA bundle with [`ty`](https://github.com/astral-sh/ty):
 
 ```bash

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -33,6 +33,7 @@ module-name = "{{ python_package_import_name }}"
 
 [tool.uv]
 exclude-newer = "1 week"
+exclude-newer-package = { ty = "0 days" }
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
This implements dependency cooldowns for generated projects using uv.

Changes:
- Add `[tool.uv]` to the project template with:
  - `exclude-newer = "1 week"`
  - `exclude-newer-package = { ty = "0 days" }`
- Add brief README notes (template README and generated project README) describing the cooldown policy.

Why this shape:
- We keep a global one-week cooldown to reduce exposure to very fresh supply-chain compromises.
- We keep `ty` available immediately to avoid conflicts with the template's minimum `ty` requirement and CI QA checks.

Reference:
- https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns

Closes #15.
