### PR TITLE
Add ty check guidance to AGENTS and fix typing issue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,5 +42,6 @@ Copier docs: https://copier.readthedocs.io/en/stable/
 - Docstrings in Markdown ("myst") format, expressing intentions rather than implementation details.
   Make references to other code if appropriate. Eg: "See also `{py:func}`other_module.helper_function`.".
 - Explicit and robust type annotations using built-in generics (`list`, `dict`, etc.), union types with `|`, etc.
+- Validate type safety with `uv run ty check` after relevant code changes.
 - Prefer flat code: use early returns, guard clauses, fixtures over context managers on tests, etc.
 - Never hallucinate APIs or behaviours. If uncertain, inspect the code and/or check online documentation (ensure it's the correct version declared by uv.lock) or ask the developer

--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -27,6 +27,7 @@ Description: {{ project_description }}
 - Docstrings in Markdown ("myst") format, expressing intentions rather than implementation details.
   Make references to other code if appropriate. Eg: "See also `{py:func}`other_module.helper_function`.".
 - Explicit and robust type annotations using built-in generics (`list`, `dict`, etc.), union types with `|`, etc.
+- Validate type safety with `uv run ty check` after relevant code changes.
 - Prefer flat code: use early returns, guard clauses, fixtures over context managers on tests, etc.
 - Never hallucinate APIs or behaviours. If uncertain, inspect the code and/or check online documentation (ensure it's the correct version declared by uv.lock) or ask the developer
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import urllib.error
+from email.message import Message
 from pathlib import Path
 
 from python_package_copier_template import cli, extensions
@@ -26,7 +27,7 @@ def test_cli_copy_and_update(tmp_path: Path, monkeypatch) -> None:
     def _fake_urlopen(_request, timeout):  # noqa: ANN001
         if project_exists_on_pypi:
             return _DummyResponse()
-        raise urllib.error.HTTPError("", 404, "not found", {}, None)
+        raise urllib.error.HTTPError("", 404, "not found", Message(), None)
 
     monkeypatch.setattr(extensions.urllib.request, "urlopen", _fake_urlopen)
     cli.main([str(dest)])


### PR DESCRIPTION
## Summary
- add explicit uv run ty check guidance to root AGENTS.md
- add the same guidance to project/AGENTS.md.jinja
- fix a ty type issue in tests/test_cli.py (HTTPError headers type)

## Validation
- uv run ty check