### PR TITLE
Relax test return annotation style in template

### DIFF
--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -27,6 +27,8 @@ Description: {{ project_description }}
 - Docstrings in Markdown ("myst") format, expressing intentions rather than implementation details.
   Make references to other code if appropriate. Eg: "See also `{py:func}`other_module.helper_function`.".
 - Explicit and robust type annotations using built-in generics (`list`, `dict`, etc.), union types with `|`, etc.
+- In tests (`tests/**/*.py`), avoid adding a return annotation (`-> None`) to `test_*` functions.
+  Ruff `ANN` rules are intentionally ignored there.
 - Validate type safety with `uv run ty check` after relevant code changes.
 - Prefer flat code: use early returns, guard clauses, fixtures over context managers on tests, etc.
 - Never hallucinate APIs or behaviours. If uncertain, inspect the code and/or check online documentation (ensure it's the correct version declared by uv.lock) or ask the developer

--- a/project/tests/{% if python_package_command_line_name %}test_cli.py{% endif %}.jinja
+++ b/project/tests/{% if python_package_command_line_name %}test_cli.py{% endif %}.jinja
@@ -11,12 +11,12 @@ import pytest
 from {{ python_package_import_name }} import get_version, main
 
 
-def test_main() -> None:
+def test_main():
     """Basic CLI test."""
     assert main([]) == 0
 
 
-def test_show_help(capsys: pytest.CaptureFixture) -> None:
+def test_show_help(capsys: pytest.CaptureFixture):
     """Show help.
 
     Parameters:
@@ -28,7 +28,7 @@ def test_show_help(capsys: pytest.CaptureFixture) -> None:
     assert "{{ python_package_command_line_name }}" in captured.out
 
 
-def test_show_version(mocker, capsys: pytest.CaptureFixture) -> None:
+def test_show_version(mocker, capsys: pytest.CaptureFixture):
     """Show version.
 
     Parameters:


### PR DESCRIPTION
## Summary
- remove `-> None` from generated `test_*` examples
- keep ANN ignored for `tests/**/*.py` (already configured)
- document this style in `project/AGENTS.md.jinja`

## Validation
- generated project from template (`copier copy --vcs-ref=HEAD --defaults`)
- ran CI smoke equivalents locally: ruff, pytest, ty check, uv build, make docs