### PR TITLE
docs: clarify gh pr body-file usage in agents guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Copier docs: https://copier.readthedocs.io/en/stable/
 - Prefer `apply_patch` for edits; avoid touching user changes you didn't make.
 - Never auto-commit/auto-push unless requested.
 - Network calls are limited to what the template already does (e.g., PyPI HEAD check).
+- For `gh pr` interactions, prefer `--body-file` with a temporary file created under `/tmp/`.
 
 ## Python preferences
 

--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -38,6 +38,7 @@ Description: {{ project_description }}
 - Ensure you are in a proper branch for each new feature or bugfix.
 - Never commit or push automatically unless instructed otherwise.
 - Prefer `gh` CLI for all interactions with Github if possible. Eg. Use it to open PRs / manage issues.
+- For `gh pr` interactions, prefer `--body-file` with a temporary file created under `/tmp/`.
 - Consider mentioning yourself in the commits as co-author if you helped enough. Use the standard Git co-author trailer:
   "Co-authored-by: Name <email>".
 


### PR DESCRIPTION
## Summary
- add a note in `AGENTS.md` to prefer `gh pr --body-file` with a temp file in `/tmp/`
- add the same note in `project/AGENTS.md.jinja`

## Testing
- not applicable (docs-only change)
