### PR TITLE
ci: avoid PR docs deploy from overwriting canonical site

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,22 +25,27 @@ permissions:
   id-token: write
 
 jobs:
+  docs-build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Build docs
+        run: uv run --group docs sphinx-build docs docs/_build/html -b html -W
+
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: docs-build
+    if: github.event_name != 'pull_request'
     environment:
-      name: ${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}
+      name: github-pages
       url: ${{ steps.preview_url.outputs.url }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Detect documentation preview target
-        id: preview
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "docs_subdir=_preview/pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          fi
 
       - uses: actions/configure-pages@v5
       - uses: astral-sh/setup-uv@v7
@@ -51,15 +56,9 @@ jobs:
       - name: Stage documentation artifact
         run: |
           out_dir="site"
-          subdir="${{ steps.preview.outputs.docs_subdir }}"
           rm -rf "$out_dir"
-          if [ -n "$subdir" ]; then
-            mkdir -p "$out_dir/$subdir"
-            cp -a docs/_build/html/. "$out_dir/$subdir/"
-          else
-            mkdir -p "$out_dir"
-            cp -a docs/_build/html/. "$out_dir/"
-          fi
+          mkdir -p "$out_dir"
+          cp -a docs/_build/html/. "$out_dir/"
 
       - uses: actions/upload-pages-artifact@v4
         with:
@@ -72,10 +71,6 @@ jobs:
         id: preview_url
         run: |
           url="${{ steps.deployment.outputs.page_url }}"
-          subdir="${{ steps.preview.outputs.docs_subdir }}"
-          if [ -n "$subdir" ]; then
-            url="${url%/}/${subdir}"
-          fi
           echo "url=${url}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize documentation URL

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Demo repo generated from this template: [mgaitan/yet-another-demo](https://githu
 - 🪝 Optional pre-commit style QA orchestration via [prek](https://github.com/j178/prek) as an external tool (`uv tool install prek`; hooks include `check-ast`, `check-yaml`, `check-toml`, Ruff, Ty)
 - 🧪 Tests with [pytest](https://docs.pytest.org/en/stable/), [coverage.py](https://coverage.readthedocs.io/en/latest/) and extensions
 - 📚 Docs with [Sphinx](https://www.sphinx-doc.org/en/master/), [MyST](https://myst-parser.readthedocs.io/en/stable/) and a few extensions, deployed to [GitHub Pages](https://pages.github.com/)
-- 👀 Automatic docs preview deployment for PRs that modify documentation (`/_preview/pr-<PR_NUMBER>/` on GitHub Pages)
+- 👀 Docs are validated on PRs, and canonical GitHub Pages deployment happens on main/manual runs
 - 🧭 Generated docs follow [Diataxis](https://diataxis.fr/) and document rationale in [`about_the_docs`](project/docs/about_the_docs.md.jinja)
 - 🏗️ Use of [GitHub CLI](https://cli.github.com/) for autotic project creation 
 - ⚙️ CI workflow on [GitHub Actions](https://github.com/features/actions)

--- a/docs/about_the_docs.md
+++ b/docs/about_the_docs.md
@@ -50,7 +50,4 @@ Equivalent direct command:
 uv run --group docs sphinx-build docs docs/_build/html -b html -W
 ```
 
-CI validates docs on every PR, and `Docs Deploy` publishes:
-
-- canonical docs from `main`,
-- PR previews under `/_preview/pr-<N>/`.
+CI validates docs on every PR, and `Docs Deploy` publishes canonical docs from `main` (push/manual runs).

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -32,36 +32,34 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release'
 
+  docs-build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v7
+      - run: make docs
+
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    needs: docs-build
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     environment:
-      name: {% raw %}${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}{% endraw %}
+      name: github-pages
       url: {% raw %}${{ steps.preview_url.outputs.url }}{% endraw %}
     steps:
       - uses: actions/checkout@v4
-      - name: Detect documentation preview target
-        id: preview
-        run: |
-          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "pull_request" ]; then
-            echo "docs_subdir=_preview/pr-{% raw %}${{ github.event.pull_request.number }}{% endraw %}" >> "$GITHUB_OUTPUT"
-          fi
       - uses: actions/configure-pages@v5
       - uses: astral-sh/setup-uv@v7
       - run: make docs
       - name: Stage documentation artifact
         run: |
           out_dir="site"
-          subdir="{% raw %}${{ steps.preview.outputs.docs_subdir }}{% endraw %}"
           rm -rf "$out_dir"
-          if [ -n "$subdir" ]; then
-            mkdir -p "$out_dir/$subdir"
-            cp -a docs/_build/html/. "$out_dir/$subdir/"
-          else
-            mkdir -p "$out_dir"
-            cp -a docs/_build/html/. "$out_dir/"
-          fi
+          mkdir -p "$out_dir"
+          cp -a docs/_build/html/. "$out_dir/"
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site
@@ -71,10 +69,6 @@ jobs:
         id: preview_url
         run: |
           url="{% raw %}${{ steps.deployment.outputs.page_url }}{% endraw %}"
-          subdir="{% raw %}${{ steps.preview.outputs.docs_subdir }}{% endraw %}"
-          if [ -n "$subdir" ]; then
-            url="${url%/}/${subdir}"
-          fi
           echo "url=${url}" >> "$GITHUB_OUTPUT"
       - name: Summarize documentation URL
         run: |

--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -52,7 +52,7 @@ Description: {{ project_description }}
 - Use `docs/about_the_docs.md` as the canonical chapter for documentation principles and design rationale.
 - Keep env var definitions in `docs/configuration.md` using the Sphinx `glossary` directive.
 - When mentioning an env var in docs, reference it as a glossary term (`{term}`).
-- Documentation previews for PRs with docs changes are published under `https://{{ repository_namespace }}.github.io/{{ repository_name }}/_preview/pr-<PR_NUMBER>/`.
+- Documentation changes in PRs are validated in CI, without publishing to the canonical site.
 - Release/manual docs publish uses the canonical site URL: `https://{{ repository_namespace }}.github.io/{{ repository_name }}/`.
 - Provide documentation for:
   - **Users:** intention, behaviour, minimal examples.

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -48,11 +48,7 @@ prek install
 prek run --all-files
 ```
 
-- PRs with documentation changes publish a docs preview at:
-
-```text
-https://{{ repository_namespace }}.github.io/{{ repository_name }}/_preview/pr-<PR_NUMBER>/
-```
+- PRs with documentation changes are validated in CI (`make docs` in the deploy workflow).
 
 ## Documentation
 

--- a/project/docs/about_the_docs.md.jinja
+++ b/project/docs/about_the_docs.md.jinja
@@ -42,8 +42,7 @@ We ship [richterm](https://github.com/mgaitan/richterm) for CLI captures and
 `gh:.github/workflows/cd.yml` deploys docs to GitHub Pages:
 
 - release/manual runs publish canonical docs,
-- PRs with docs changes publish previews under
-  `https://{{ repository_namespace }}.github.io/{{ repository_name }}/_preview/pr-<PR_NUMBER>/`.
+- PRs with docs changes validate docs builds without publishing to the canonical site.
 
 For manual dispatch using `gh` CLI, authentication usually relies on {term}`GH_TOKEN`.
 Workflow internals rely on {term}`GITHUB_TOKEN`.

--- a/project/docs/development_workflow.md.jinja
+++ b/project/docs/development_workflow.md.jinja
@@ -35,15 +35,11 @@ make release
 
 Release workflows publish package artifacts and canonical docs.
 
-## Preview documentation in pull requests
+## Documentation deployment
 
-When docs files change in a PR, CI deploys a preview to:
+When docs files change in a PR, CI validates documentation builds.
 
-```text
-https://{{ repository_namespace }}.github.io/{{ repository_name }}/_preview/pr-<PR_NUMBER>/
-```
-
-If needed, dispatch docs publishing manually:
+Canonical docs are published by release workflows, and can also be published manually if needed:
 
 ```bash
 gh workflow run cd.yml --ref main


### PR DESCRIPTION
## Summary
- prevent PR doc workflows from deploying to GitHub Pages root
- publish canonical docs only on non-PR events in template repo docs workflow
- in generated projects, publish canonical docs only on `release` or manual dispatch
- update template docs/agent guidance to reflect this behavior

## Why
`actions/deploy-pages` publishes the full artifact and can replace root content. PR previews in a partial artifact can overwrite canonical docs.

## Validation
- workflow logic reviewed in both template and generated workflow templates
- documentation references aligned with the new behavior
