### PR TITLE
ci: keep canonical docs while publishing PR previews

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,39 +25,57 @@ permissions:
   id-token: write
 
 jobs:
+  docs-build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+      - name: Build docs
+        run: uv run --group docs sphinx-build docs docs/_build/html -b html -W
+
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
+    needs: docs-build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     environment:
       name: ${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}
       url: ${{ steps.preview_url.outputs.url }}
     steps:
       - uses: actions/checkout@v4
-
-      - name: Detect documentation preview target
-        id: preview
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "docs_subdir=_preview/pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          fi
-
+        with:
+          fetch-depth: 0
       - uses: actions/configure-pages@v5
       - uses: astral-sh/setup-uv@v7
 
-      - name: Build docs
-        run: uv run --group docs sphinx-build docs docs/_build/html -b html -W
-
       - name: Stage documentation artifact
         run: |
+          set -euo pipefail
           out_dir="site"
-          subdir="${{ steps.preview.outputs.docs_subdir }}"
           rm -rf "$out_dir"
-          if [ -n "$subdir" ]; then
-            mkdir -p "$out_dir/$subdir"
-            cp -a docs/_build/html/. "$out_dir/$subdir/"
+          mkdir -p "$out_dir"
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pr_number="${{ github.event.pull_request.number }}"
+            git fetch origin main --depth=1
+            stable_dir="$(mktemp -d)"
+            git worktree add "$stable_dir" origin/main
+            (
+              cd "$stable_dir"
+              uv run --group docs sphinx-build docs docs/_build/html -b html -W
+            )
+            cp -a "$stable_dir/docs/_build/html/." "$out_dir/"
+            git worktree remove "$stable_dir" --force
+
+            uv run --group docs sphinx-build docs docs/_build/html -b html -W
+            mkdir -p "$out_dir/_preview/pr-$pr_number"
+            cp -a docs/_build/html/. "$out_dir/_preview/pr-$pr_number/"
           else
-            mkdir -p "$out_dir"
+            uv run --group docs sphinx-build docs docs/_build/html -b html -W
             cp -a docs/_build/html/. "$out_dir/"
           fi
 
@@ -72,9 +90,8 @@ jobs:
         id: preview_url
         run: |
           url="${{ steps.deployment.outputs.page_url }}"
-          subdir="${{ steps.preview.outputs.docs_subdir }}"
-          if [ -n "$subdir" ]; then
-            url="${url%/}/${subdir}"
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            url="${url%/}/_preview/pr-${{ github.event.pull_request.number }}/"
           fi
           echo "url=${url}" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,19 @@ on:
       - "pyproject.toml"
       - ".github/workflows/cd.yml"
   workflow_dispatch:
+    inputs:
+      deploy_target:
+        description: "Deployment target"
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - preview
+      pr_number:
+        description: "PR number (required when deploy_target=preview)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -28,7 +41,7 @@ jobs:
   docs-build:
     name: Build documentation
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:
@@ -40,10 +53,9 @@ jobs:
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
-    needs: docs-build
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     environment:
-      name: ${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}
+      name: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'preview' && 'github-pages-preview' || 'github-pages' }}
       url: ${{ steps.preview_url.outputs.url }}
     steps:
       - uses: actions/checkout@v4
@@ -59,8 +71,13 @@ jobs:
           rm -rf "$out_dir"
           mkdir -p "$out_dir"
 
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pr_number="${{ github.event.pull_request.number }}"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.deploy_target }}" = "preview" ]; then
+            pr_number="${{ github.event.inputs.pr_number }}"
+            if [ -z "$pr_number" ]; then
+              echo "pr_number is required when deploy_target=preview" >&2
+              exit 1
+            fi
+
             git fetch origin main --depth=1
             stable_dir="$(mktemp -d)"
             git worktree add "$stable_dir" origin/main
@@ -71,9 +88,17 @@ jobs:
             cp -a "$stable_dir/docs/_build/html/." "$out_dir/"
             git worktree remove "$stable_dir" --force
 
-            uv run --group docs sphinx-build docs docs/_build/html -b html -W
-            mkdir -p "$out_dir/_preview/pr-$pr_number"
-            cp -a docs/_build/html/. "$out_dir/_preview/pr-$pr_number/"
+            preview_ref="refs/remotes/origin/pr-preview-$pr_number"
+            git fetch origin "pull/$pr_number/head:pr-preview-$pr_number"
+            preview_dir="$(mktemp -d)"
+            git worktree add "$preview_dir" "$preview_ref"
+            (
+              cd "$preview_dir"
+              uv run --group docs sphinx-build docs docs/_build/html -b html -W
+            )
+            mkdir -p "$out_dir/_preview"
+            cp -a "$preview_dir/docs/_build/html/." "$out_dir/_preview/"
+            git worktree remove "$preview_dir" --force
           else
             uv run --group docs sphinx-build docs docs/_build/html -b html -W
             cp -a docs/_build/html/. "$out_dir/"
@@ -90,8 +115,8 @@ jobs:
         id: preview_url
         run: |
           url="${{ steps.deployment.outputs.page_url }}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            url="${url%/}/_preview/pr-${{ github.event.pull_request.number }}/"
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ github.event.inputs.deploy_target }}" = "preview" ]; then
+            url="${url%/}/_preview/"
           fi
           echo "url=${url}" >> "$GITHUB_OUTPUT"
 

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -12,6 +12,19 @@ on:
       - "CONTRIBUTING.md"
       - ".github/workflows/cd.yml"
   workflow_dispatch:
+    inputs:
+      deploy_target:
+        description: "Deployment target"
+        required: true
+        default: stable
+        type: choice
+        options:
+          - stable
+          - preview
+      pr_number:
+        description: "PR number (required when deploy_target=preview)"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -35,7 +48,7 @@ jobs:
   docs-build:
     name: Build documentation
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:
@@ -46,10 +59,9 @@ jobs:
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
-    needs: docs-build
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     environment:
-      name: {% raw %}${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}{% endraw %}
+      name: {% raw %}${{ github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'preview' && 'github-pages-preview' || 'github-pages' }}{% endraw %}
       url: {% raw %}${{ steps.preview_url.outputs.url }}{% endraw %}
     steps:
       - uses: actions/checkout@v4
@@ -64,9 +76,17 @@ jobs:
           rm -rf "$out_dir"
           mkdir -p "$out_dir"
 
-          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "pull_request" ]; then
-            pr_number="{% raw %}${{ github.event.pull_request.number }}{% endraw %}"
-            latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "workflow_dispatch" ] && [ "{% raw %}${{ github.event.inputs.deploy_target }}{% endraw %}" = "preview" ]; then
+            pr_number="{% raw %}${{ github.event.inputs.pr_number }}{% endraw %}"
+            if [ -z "$pr_number" ]; then
+              echo "pr_number is required when deploy_target=preview" >&2
+              exit 1
+            fi
+
+            latest_tag="$(git tag --sort=-version:refname | head -n1 || true)"
+            if [ -z "$latest_tag" ]; then
+              latest_tag="$(git tag --sort=-creatordate | head -n1 || true)"
+            fi
             if [ -n "$latest_tag" ]; then
               stable_dir="$(mktemp -d)"
               git worktree add "$stable_dir" "$latest_tag"
@@ -81,13 +101,22 @@ jobs:
               cp -a docs/_build/html/. "$out_dir/"
             fi
 
-            make docs
-            mkdir -p "$out_dir/_preview/pr-$pr_number"
-            cp -a docs/_build/html/. "$out_dir/_preview/pr-$pr_number/"
+            preview_ref="refs/remotes/origin/pr-preview-$pr_number"
+            git fetch origin "pull/$pr_number/head:pr-preview-$pr_number"
+            preview_dir="$(mktemp -d)"
+            git worktree add "$preview_dir" "$preview_ref"
+            (
+              cd "$preview_dir"
+              make docs
+            )
+            mkdir -p "$out_dir/_preview"
+            cp -a "$preview_dir/docs/_build/html/." "$out_dir/_preview/"
+            git worktree remove "$preview_dir" --force
           else
             make docs
             cp -a docs/_build/html/. "$out_dir/"
           fi
+
       - uses: actions/upload-pages-artifact@v4
         with:
           path: site
@@ -97,8 +126,8 @@ jobs:
         id: preview_url
         run: |
           url="{% raw %}${{ steps.deployment.outputs.page_url }}{% endraw %}"
-          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "pull_request" ]; then
-            url="${url%/}/_preview/pr-{% raw %}${{ github.event.pull_request.number }}{% endraw %}/"
+          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "workflow_dispatch" ] && [ "{% raw %}${{ github.event.inputs.deploy_target }}{% endraw %}" = "preview" ]; then
+            url="${url%/}/_preview/"
           fi
           echo "url=${url}" >> "$GITHUB_OUTPUT"
       - name: Summarize documentation URL

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -32,34 +32,60 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release'
 
+  docs-build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v7
+      - run: make docs
+
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
+    needs: docs-build
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     environment:
       name: {% raw %}${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}{% endraw %}
       url: {% raw %}${{ steps.preview_url.outputs.url }}{% endraw %}
     steps:
       - uses: actions/checkout@v4
-      - name: Detect documentation preview target
-        id: preview
-        run: |
-          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "pull_request" ]; then
-            echo "docs_subdir=_preview/pr-{% raw %}${{ github.event.pull_request.number }}{% endraw %}" >> "$GITHUB_OUTPUT"
-          fi
+        with:
+          fetch-depth: 0
       - uses: actions/configure-pages@v5
       - uses: astral-sh/setup-uv@v7
-      - run: make docs
       - name: Stage documentation artifact
         run: |
+          set -euo pipefail
           out_dir="site"
-          subdir="{% raw %}${{ steps.preview.outputs.docs_subdir }}{% endraw %}"
           rm -rf "$out_dir"
-          if [ -n "$subdir" ]; then
-            mkdir -p "$out_dir/$subdir"
-            cp -a docs/_build/html/. "$out_dir/$subdir/"
+          mkdir -p "$out_dir"
+
+          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "pull_request" ]; then
+            pr_number="{% raw %}${{ github.event.pull_request.number }}{% endraw %}"
+            latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+            if [ -n "$latest_tag" ]; then
+              stable_dir="$(mktemp -d)"
+              git worktree add "$stable_dir" "$latest_tag"
+              (
+                cd "$stable_dir"
+                make docs
+              )
+              cp -a "$stable_dir/docs/_build/html/." "$out_dir/"
+              git worktree remove "$stable_dir" --force
+            else
+              make docs
+              cp -a docs/_build/html/. "$out_dir/"
+            fi
+
+            make docs
+            mkdir -p "$out_dir/_preview/pr-$pr_number"
+            cp -a docs/_build/html/. "$out_dir/_preview/pr-$pr_number/"
           else
-            mkdir -p "$out_dir"
+            make docs
             cp -a docs/_build/html/. "$out_dir/"
           fi
       - uses: actions/upload-pages-artifact@v4
@@ -71,9 +97,8 @@ jobs:
         id: preview_url
         run: |
           url="{% raw %}${{ steps.deployment.outputs.page_url }}{% endraw %}"
-          subdir="{% raw %}${{ steps.preview.outputs.docs_subdir }}{% endraw %}"
-          if [ -n "$subdir" ]; then
-            url="${url%/}/${subdir}"
+          if [ "{% raw %}${{ github.event_name }}{% endraw %}" = "pull_request" ]; then
+            url="${url%/}/_preview/pr-{% raw %}${{ github.event.pull_request.number }}{% endraw %}/"
           fi
           echo "url=${url}" >> "$GITHUB_OUTPUT"
       - name: Summarize documentation URL


### PR DESCRIPTION
## Summary
- preserve canonical docs while still publishing PR previews
- for template repo docs workflow, build canonical root from `main` on PR preview deploys
- for generated projects, build canonical root from latest release tag on PR preview deploys
- publish PR preview docs under `/_preview/pr-<PR_NUMBER>/`

## Why
`actions/deploy-pages` replaces the full published site with the uploaded artifact. Deploying only preview files can remove canonical docs.

## Notes
- This keeps both: stable canonical root and PR preview URLs.
