### PR TITLE
Preserve stable docs when publishing PR previews

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,20 +85,31 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: astral-sh/setup-uv@v7
 
-      - name: Build docs
-        run: uv run --group docs sphinx-build docs docs/_build/html -b html -W
+      - name: Build docs for current ref
+        run: |
+          uv run --group docs sphinx-build docs docs/_build/html -b html -W
+          mv docs/_build/html docs/_build/html-current
+
+      - name: Build stable docs from main
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin main --depth=1
+          git worktree add ../template-main origin/main
+          cd ../template-main
+          uv run --group docs sphinx-build docs docs/_build/html -b html -W
 
       - name: Stage documentation artifact
         run: |
           out_dir="site"
           subdir="${{ steps.preview.outputs.docs_subdir }}"
           rm -rf "$out_dir"
+          mkdir -p "$out_dir"
           if [ -n "$subdir" ]; then
+            cp -a ../template-main/docs/_build/html/. "$out_dir/"
             mkdir -p "$out_dir/$subdir"
-            cp -a docs/_build/html/. "$out_dir/$subdir/"
+            cp -a docs/_build/html-current/. "$out_dir/$subdir/"
           else
-            mkdir -p "$out_dir"
-            cp -a docs/_build/html/. "$out_dir/"
+            cp -a docs/_build/html-current/. "$out_dir/"
           fi
 
       - uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary

This fixes documentation preview deployments so pull requests no longer replace the stable GitHub Pages site with a preview-only artifact.

On PRs, the workflow now:

- builds the docs for the PR ref
- rebuilds the stable docs from `origin/main`
- publishes the stable site at the root
- publishes the PR preview under `/_preview/pr-<PR_NUMBER>/`

## Why

The previous workflow staged only `site/_preview/pr-<N>/...` for PR deployments. Since `actions/deploy-pages` replaces the whole Pages artifact, this could leave the root site empty or broken while the preview existed.

## Validation

- workflow YAML parsed successfully
- reviewed the generated artifact staging logic against the failing case observed in `richterm`
