### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,10 +35,10 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
       - run: uv publish
 
@@ -71,7 +71,7 @@ jobs:
       name: ${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}
       url: ${{ steps.preview_url.outputs.url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -83,7 +83,7 @@ jobs:
           fi
 
       - uses: actions/configure-pages@v5
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Build docs for current ref
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Lint GitHub workflows
-        uses: rhysd/actionlint@v1.7.9
+        uses: rhysd/actionlint@v1.7.12
 
       - name: Configure Git
         run: |
@@ -26,7 +26,7 @@ jobs:
           git config --global user.email "bot@example.com"
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Template package docs
         run: uv run --group docs sphinx-build docs docs/_build/html -b html -W

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -35,8 +35,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
       - run: uv publish
 
@@ -66,7 +66,7 @@ jobs:
       name: {% raw %}${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}{% endraw %}
       url: {% raw %}${{ steps.preview_url.outputs.url }}{% endraw %}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Detect documentation preview target
         id: preview
         run: |
@@ -74,7 +74,7 @@ jobs:
             echo "docs_subdir=_preview/pr-{% raw %}${{ github.event.pull_request.number }}{% endraw %}" >> "$GITHUB_OUTPUT"
           fi
       - uses: actions/configure-pages@v5
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: make docs
       - name: Stage documentation artifact
         run: |

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -11,16 +11,16 @@ jobs:
   workflows-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Lint GitHub workflows
-        uses: rhysd/actionlint@v1.7.9
+        uses: rhysd/actionlint@v1.7.12
 
   qa:
     needs: workflows-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Ruff check
         run: uv run --only-group lint ruff check --output-format=github
@@ -40,7 +40,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
       - name: Run tests with coverage
         run: uv run --group test -p {% raw %}${{ matrix.python-version }}{% endraw %} pytest

--- a/project/.github/workflows/template-update.yml.jinja
+++ b/project/.github/workflows/template-update.yml.jinja
@@ -13,8 +13,8 @@ jobs:
   update-template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Capture template version (before)
         id: template-version-before
@@ -32,7 +32,7 @@ jobs:
           echo "after=$after" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: update project template"
           title: "chore: update project template to {% raw %}${{ steps.template-version-after.outputs.after }}"


### PR DESCRIPTION
## Summary

- Updates the template repository workflows to current GitHub Actions versions.
- Updates generated project workflow templates under `project/.github/workflows` with the same action versions.
- Uses the concrete `astral-sh/setup-uv@v8.2.0` tag because `astral-sh/setup-uv@v8` does not exist.

## Verified tags

- `actions/checkout@v6`
- `astral-sh/setup-uv@v8.2.0`
- `rhysd/actionlint@v1.7.12`
- `peter-evans/create-pull-request@v8`
- existing Pages actions remain valid: `configure-pages@v5`, `upload-pages-artifact@v4`, `deploy-pages@v4`

## Checks

- `uv run ruff check .`
- `uv run --group qa ty check`
- `uv run pytest`
- `make docs`
