### PR TITLE
fix: use copier update action

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ uvx --with=copier-template-extensions copier update . --trust
 
 This will fetch the latest template version and guide you through updating your project, preserving your customizations whenever possible.
 
-The generated project also ships a `Template Update` GitHub Actions workflow that runs every 20 days (or on manual dispatch) to execute `uvx copier update --trust --defaults .` and open a pull request with the changes and template version bump.
+The generated project also ships a `Template Update` GitHub Actions workflow that runs every 20 days (or on manual dispatch) with `actions-ext/copier/update@main` and opens a pull request when the template changes. Configure a `WORKFLOW_TOKEN` secret with repository contents, pull request, and workflow write permissions so template updates can include `.github/workflows/` changes.
 
 To test a local development version of the template, clone the repository and run:
 

--- a/project/.github/workflows/template-update.yml.jinja
+++ b/project/.github/workflows/template-update.yml.jinja
@@ -13,35 +13,6 @@ jobs:
   update-template:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.2.0
-
-      - name: Capture template version (before)
-        id: template-version-before
-        run: |
-          before=$(yq -r '._commit // "unknown"' .copier-answers.yml)
-          echo "before=$before" >> "$GITHUB_OUTPUT"
-
-      - name: Refresh from template
-        run: uvx git+https://github.com/mgaitan/python-package-copier-template -- .
-
-      - name: Capture template version (after)
-        id: template-version-after
-        run: |
-          after=$(yq -r '._commit // "unknown"' .copier-answers.yml)
-          echo "after=$after" >> "$GITHUB_OUTPUT"
-
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v8
+      - uses: actions-ext/copier/update@main
         with:
-          commit-message: "chore: update project template"
-          title: "chore: update project template to {% raw %}${{ steps.template-version-after.outputs.after }}"
-          body: |
-            Automated template refresh via `uvx copier update --trust --defaults .`.
-
-            Template version:
-            - before: {% raw %}${{ steps.template-version-before.outputs.before }}{% endraw %}
-            - after: {% raw %}${{ steps.template-version-after.outputs.after }}{% endraw %}
-
-            Template releases: https://github.com/mgaitan/python-package-copier-template/releases
-          branch: chore/update-template
+          token: {% raw %}${{ secrets.WORKFLOW_TOKEN }}{% endraw %}


### PR DESCRIPTION
## Summary
- replace the generated custom template-update workflow with `actions-ext/copier/update@main`
- document the `WORKFLOW_TOKEN` permissions needed for workflow file updates

## Validation
- `uv run copier copy --trust --vcs-ref=HEAD . /tmp/pct-action-test --defaults --data gh_repo_create=skip`

Closes #60
