### PR TITLE
docs: clarify agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ Copier docs: https://copier.readthedocs.io/en/stable/
 - Never auto-commit/auto-push unless requested.
 - Network calls are limited to what the template already does (e.g., PyPI HEAD check).
 - For `gh pr` interactions, prefer `--body-file` with a temporary file created under `/tmp/`.
-- After opening a PR, use `gh pr edit --add-reviewer @copilot` when Copilot review is useful for early feedback.
+- To request review from a specific user or agent, use `gh`; for example, `gh pr edit --add-reviewer @copilot`.
 - When a repository defines release targets in `Makefile`, prefer those targets over ad-hoc release commands. Use the repository's release target to run checks and publish a release. When preparing a version-bump PR, use its bump target.
 - If you need to credit an AI collaborator explicitly, use a standard co-author trailer such as:
   - "Co-authored-by: codex <codex@openai.com>".

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,13 @@ Copier docs: https://copier.readthedocs.io/en/stable/
 - Scaffold a basic Python package with `uv`, CLI entrypoint, tests, docs, CI/CD (GitHub Actions), and optional PyPI publishing.
 - Supports optional GitHub repo creation via the `gh` CLI and an early PyPI name check.
 
+## Scope: Template Package vs Generated Project
+- This repository (`python-package-copier-template`) is itself a Python package. Keep its own package code, docs, CI, and release workflow healthy.
+- The generated project skeleton lives under `project/`. Changes there affect repositories created or updated from the template.
+- Most standards should match in both places: if you improve linting, docs, workflows, Python style, or agent guidance for the template package, consider whether the same expectation belongs in `project/`.
+- Keep exceptions explicit. The template package may need extra Copier-specific docs, tests, or release automation that generated projects should not inherit.
+- `mgaitan/yet-another-repo` is the canonical example repository for this template. Use experiment branches there when validating template behavior against a real generated project.
+
 ## Quick Facts for Agents
 - Template entrypoint: `copier.yml` (prompts, defaults, tasks).
 - Jinja helpers: see `python_package_copier_template/extensions.py` (slugify, PyPI check/suggestion, gh username/availability).
@@ -29,6 +36,7 @@ Copier docs: https://copier.readthedocs.io/en/stable/
 - Never auto-commit/auto-push unless requested.
 - Network calls are limited to what the template already does (e.g., PyPI HEAD check).
 - For `gh pr` interactions, prefer `--body-file` with a temporary file created under `/tmp/`.
+- After opening a PR, use `gh pr edit --add-reviewer @copilot` when Copilot review is useful for early feedback.
 - When a repository defines release targets in `Makefile`, prefer those targets over ad-hoc release commands. Use the repository's release target to run checks and publish a release. When preparing a version-bump PR, use its bump target.
 - If you need to credit an AI collaborator explicitly, use a standard co-author trailer such as:
   - "Co-authored-by: codex <codex@openai.com>".

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ Canonical example repo generated from this template: [mgaitan/yet-another-repo](
 
 Documentation: <https://mgaitan.github.io/python-package-copier-template/>
 
-Sister project for Django internal management systems:
-[mgaitan/django-unfold-copier-template](https://github.com/mgaitan/django-unfold-copier-template).
-
 ## Features
 
 - 🐍 Modern Python package (3.12+)
@@ -37,6 +34,10 @@ Sister project for Django internal management systems:
 - 🌀 Initial setup of the development environment and git repo
 - 🔁 Scheduled template refresh workflow that opens a PR every 20 days when updates are available
 - ♻️ Projects updatable with [`copier update`](https://copier.readthedocs.io/en/stable/updating/)
+
+> [!NOTE]
+> Sister project for Django internal management systems:
+> [mgaitan/django-unfold-copier-template](https://github.com/mgaitan/django-unfold-copier-template).
 
 Please read [my blog post](https://mgaitan.github.io/en/posts/opinionated-python-project-scaffolding/) to learn about the details of the decisions I made and the alternatives I considered.
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 A [Copier](https://github.com/copier-org/copier) template
 for modern Python projects. 
 
-Demo repo generated from this template: [mgaitan/yet-another-demo](https://github.com/mgaitan/yet-another-demo)
+Canonical example repo generated from this template: [mgaitan/yet-another-repo](https://github.com/mgaitan/yet-another-repo)
 
 Documentation: <https://mgaitan.github.io/python-package-copier-template/>
 
-Related template for Django internal management systems:
+Sister project for Django internal management systems:
 [mgaitan/django-unfold-copier-template](https://github.com/mgaitan/django-unfold-copier-template).
 
 ## Features

--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -166,7 +166,7 @@ The point is to reduce the amount of “project setup work” that usually gets 
 
 ## Demo repository
 
-The template is exercised continuously against [mgaitan/yet-another-demo](https://github.com/mgaitan/yet-another-demo), a public repository generated from this scaffold.
+The canonical generated-project example is [mgaitan/yet-another-repo](https://github.com/mgaitan/yet-another-repo). Use experiment branches there when validating changes against a real repository created from this scaffold.
 That demo is useful for three different reasons:
 
 - it shows what the scaffold looks like after rendering,

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ The wrapper decides whether to run `copier copy` or `copier update` by inspectin
 If you want the details of how the wrapper resolves template versions and source locations, see [CLI Reference](cli.md).
 If you prefer the raw Copier commands, or want the latest development version from GitHub, the details are in [Getting Started](getting_started.md).
 
-A public example generated from the template lives at [mgaitan/yet-another-demo](https://github.com/mgaitan/yet-another-demo).
+The canonical example generated from the template lives at [mgaitan/yet-another-repo](https://github.com/mgaitan/yet-another-repo).
 It is useful both as a smoke target and as a concrete reference for what the scaffold looks like in practice.
 
 ## What this template includes

--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -17,7 +17,7 @@ Description: {{ project_description }}
 - **Tests:** pytest, factory-boy, pytest-mock. `make test` to run tests. or `uv run pytest`
 - **Productivity:** Dependencies managed with `uv` via `pyproject.toml`;
 - **lint/format:** Ruff.
-- **Git:** and Github
+- **Git:** and GitHub
 
 ## Python preferences
 
@@ -38,13 +38,13 @@ Description: {{ project_description }}
 - Prefer flat code: use early returns, guard clauses, fixtures over context managers on tests, etc.
 - Never hallucinate APIs or behaviours. If uncertain, inspect the code and/or check online documentation (ensure it's the correct version declared by uv.lock) or ask the developer
 
-## Git/Github preferences
+## Git/GitHub preferences
 
 - Ensure you are in a proper branch for each new feature or bugfix.
 - Never commit or push automatically unless instructed otherwise.
-- Prefer `gh` CLI for all interactions with Github if possible. Eg. Use it to open PRs / manage issues.
+- Prefer `gh` CLI for all interactions with GitHub if possible. Eg. Use it to open PRs / manage issues.
 - For `gh pr` interactions, prefer `--body-file` with a temporary file created under `/tmp/`.
-- After opening a PR, use `gh pr edit --add-reviewer @copilot` when Copilot review is useful for early feedback.
+- To request review from a specific user or agent, use `gh`; for example, `gh pr edit --add-reviewer @copilot`.
 - When a repository defines release targets in `Makefile`, prefer those targets over ad-hoc release commands. Use the repository's release target to run checks and publish a release. When preparing a version-bump PR, use its bump target.
 - For issue categorization, use GitHub labels instead of title prefixes like `Bug:`, `Feat:`, or `Docs:`.
 - Before assigning labels, inspect labels already used in the target repository and follow that taxonomy first.
@@ -75,6 +75,6 @@ Description: {{ project_description }}
 
 ## Language preferences
 
-- The public language is English: all committable text and Github interactions must be in simple English (including documentation, comments, docstrings, commit messages, PR descriptions, etc.).
+- The public language is English: all committable text and GitHub interactions must be in simple English (including documentation, comments, docstrings, commit messages, PR descriptions, etc.).
 - However, when interacting with the developer in chat, respond in the language they use.
 - Avoid sexist or exclusionary language. Always prefer gender-neutral phrasing.

--- a/project/AGENTS.md.jinja
+++ b/project/AGENTS.md.jinja
@@ -4,6 +4,13 @@ Repository: https://github.com/{{ repository_namespace }}/{{ repository_name }}
 
 Description: {{ project_description }}
 
+## Project Scope
+
+- This repository is generated from `mgaitan/python-package-copier-template`.
+- Keep local project code, docs, CI, and release automation aligned with the template defaults unless the project has an intentional reason to diverge.
+- When updating from the template, review generated changes carefully and preserve project-specific behavior.
+- `mgaitan/yet-another-repo` is the canonical example repository for this template. Use experiment branches there when validating template behavior before adopting it here.
+
 ## Stack
 
 - **Python:** Python 3.14. Check main dependencies in `pyproject.toml`.
@@ -37,6 +44,7 @@ Description: {{ project_description }}
 - Never commit or push automatically unless instructed otherwise.
 - Prefer `gh` CLI for all interactions with Github if possible. Eg. Use it to open PRs / manage issues.
 - For `gh pr` interactions, prefer `--body-file` with a temporary file created under `/tmp/`.
+- After opening a PR, use `gh pr edit --add-reviewer @copilot` when Copilot review is useful for early feedback.
 - When a repository defines release targets in `Makefile`, prefer those targets over ad-hoc release commands. Use the repository's release target to run checks and publish a release. When preparing a version-bump PR, use its bump target.
 - For issue categorization, use GitHub labels instead of title prefixes like `Bug:`, `Feat:`, or `Docs:`.
 - Before assigning labels, inspect labels already used in the target repository and follow that taxonomy first.


### PR DESCRIPTION
## Summary
- clarify when guidance applies to this template package vs generated projects under `project/`
- add Copilot reviewer guidance to both AGENTS files
- name `mgaitan/yet-another-repo` as the canonical example repo for experiments
- call the Django Unfold template a sister project in the README

## Validation
- documentation-only change; reviewed rendered Markdown diff
