### PR TITLE
feat: allow projects without a license

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Related template for Django internal management systems:
 - 🚀 Automated releases to PyPI via [Trusted Publishing](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
 - 🧠 Sensible defaults via introspection to minimize answers during the initial setup
 - 🛠️ Makefile with shortcuts for common tasks
-- 📄 Generation of generic docs such as `LICENSE`, `CODE_OF_CONDUCT`, etc.
+- 📄 Generation of generic docs such as `CODE_OF_CONDUCT`, plus an optional `LICENSE`
 - 🤖 Heavily curated [AGENTS.md](https://agents.md/)
 - 🌀 Initial setup of the development environment and git repo
 - 🔁 Scheduled template refresh workflow that opens a PR every 20 days when updates are available

--- a/copier.yml
+++ b/copier.yml
@@ -130,7 +130,7 @@ repository_name:
 copyright_license:
   type: str
   help: Your project's license
-  default: "{{ 'none' if gh_repo_create | default('private') == 'private' else 'BSD-3-Clause' }}"
+  default: "{{ 'none' if ('gh' | command_available) and gh_repo_create == 'private' else 'BSD-3-Clause' }}"
   choices:
     No license: none
     BSD 3-Clause "New" or "Revised" License: BSD-3-Clause

--- a/copier.yml
+++ b/copier.yml
@@ -8,6 +8,7 @@ _templates_suffix: .jinja
 _preserve_symlinks: true
 _exclude:
   - "{% if not ('prek' | command_available) %}prek.toml{% endif %}"
+  - "{% if copyright_license == 'none' %}LICENSE{% endif %}"
 _jinja_extensions:
   - copier_template_extensions.TemplateExtensionLoader
   - python_package_copier_template.extensions:CurrentYearExtension
@@ -129,8 +130,9 @@ repository_name:
 copyright_license:
   type: str
   help: Your project's license
-  default: BSD-3-Clause
+  default: "{{ 'none' if gh_repo_create | default('private') == 'private' else 'BSD-3-Clause' }}"
   choices:
+    No license: none
     BSD 3-Clause "New" or "Revised" License: BSD-3-Clause
     MIT License: MIT
     Apache License 2.0: Apache-2.0

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,3 +17,11 @@ DEMO_REPO_TOKEN
   Repository secret used by this template repository's release workflow to push updates to the demo repository `mgaitan/yet-another-demo`.
   Use a fine-grained token with `Contents: Read and write` on that repository.
 ```
+
+## Template Choices
+
+`copyright_license` controls generated package license metadata, the `LICENSE`
+file, and license badges. Public repositories default to `BSD-3-Clause`;
+explicitly private repositories default to `none`, which omits license metadata
+and does not generate a `LICENSE` file. Local copies that skip GitHub repository
+creation keep the licensed `BSD-3-Clause` default.

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -6,7 +6,9 @@
 [![Changelog](https://img.shields.io/github/v/release/{{ repository_namespace }}/{{ repository_name }}?include_prereleases&label=changelog)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/releases)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/actions/workflows/ci.yml)
 [![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
+{% if copyright_license != 'none' -%}
+[![License](https://img.shields.io/badge/license-{{ copyright_license }}-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
+{% endif %}
 
 {{ project_description }}
 

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -7,7 +7,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/actions/workflows/ci.yml)
 [![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 {% if copyright_license != 'none' -%}
-[![License](https://img.shields.io/badge/license-{{ copyright_license }}-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-{{ copyright_license | replace('-', '--') }}-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
 {% endif %}
 
 {{ project_description }}

--- a/project/docs/index.md.jinja
+++ b/project/docs/index.md.jinja
@@ -6,7 +6,9 @@
 [![Changelog](https://img.shields.io/github/v/release/{{ repository_namespace }}/{{ repository_name }}?include_prereleases&label=changelog)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/releases)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/actions/workflows/ci.yml)
 [![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
+{% if copyright_license != 'none' -%}
+[![License](https://img.shields.io/badge/license-{{ copyright_license }}-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
+{% endif %}
 
 {{ project_description }}
 

--- a/project/docs/index.md.jinja
+++ b/project/docs/index.md.jinja
@@ -7,7 +7,7 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/actions/workflows/ci.yml)
 [![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
 {% if copyright_license != 'none' -%}
-[![License](https://img.shields.io/badge/license-{{ copyright_license }}-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-{{ copyright_license | replace('-', '--') }}-blue.svg)](https://github.com/{{ repository_namespace }}/{{ repository_name }}/blob/main/LICENSE)
 {% endif %}
 
 {{ project_description }}

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -2,8 +2,10 @@
 name = "{{ python_package_distribution_name }}"
 description = "{{ project_description }}"
 authors = [{name = "{{ author_fullname }}", email = "{{ author_email }}"}]
+{% if copyright_license != 'none' -%}
 license = "{{ copyright_license }}"
 license-files = ["LICENSE"]
+{% endif -%}
 readme = "README.md"
 requires-python = ">=3.12"
 keywords = []


### PR DESCRIPTION
## Summary
- add a `No license` copier choice
- default private repositories to no license while keeping public repositories on BSD-3-Clause
- skip generated `LICENSE`, license metadata, and license badges when no license is selected
- make license badges reflect the selected SPDX value

## Validation
- `uv run copier copy --trust --vcs-ref=HEAD . /tmp/pct-no-license --defaults --data gh_repo_create=private`
- `uv run copier copy --trust --vcs-ref=HEAD . /tmp/pct-public-license --defaults --data gh_repo_create=public`
- `uv build` in `/tmp/pct-no-license`

Closes #64
