### PR TITLE
docs: enable mermaid fenced directives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,3 +28,5 @@ myst_url_schemes = {
         "classes": ["github"],
     },
 }
+
+myst_fence_as_directive = ["mermaid"]

--- a/project/docs/conf.py.jinja
+++ b/project/docs/conf.py.jinja
@@ -41,3 +41,5 @@ myst_url_schemes = {
         "classes": ["github"],
     },
 }
+
+myst_fence_as_directive = ["mermaid"]


### PR DESCRIPTION
## Summary
- configure MyST to treat fenced `mermaid` blocks as directives
- apply the same Sphinx config to the template package docs and generated project docs

## Validation
- `uv run --group docs sphinx-build docs docs/_build/html -b html -W`
- `uv run copier copy --trust --vcs-ref=HEAD . /tmp/pct-mermaid-test --defaults --data gh_repo_create=skip`
- `make docs` in `/tmp/pct-mermaid-test`

Closes #66
