### PR TITLE
fix: preserve project docs on template updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ To upgrade an existing project created from this template to the latest version,
 uvx --with=copier-template-extensions copier update . --trust 
 ```
 
-This will fetch the latest template version and guide you through updating your project, preserving your customizations whenever possible.
+This fetches the latest template version and guides you through updating your project.
+Existing `README.md` and `docs/**` files are left untouched so project-specific
+documentation is not replaced. New documentation files are still added when the
+template introduces them; adopt later changes to existing pages manually from the
+template diff when they are relevant to your project.
 
 The generated project also ships a `Template Update` GitHub Actions workflow that runs every 20 days (or on manual dispatch) to execute `uvx copier update --trust --defaults .` and open a pull request with the changes and template version bump.
 

--- a/copier.yml
+++ b/copier.yml
@@ -9,6 +9,9 @@ _preserve_symlinks: true
 _exclude:
   - "{% if not ('prek' | command_available) %}prek.toml{% endif %}"
   - "{% if copyright_license == 'none' %}LICENSE{% endif %}"
+_skip_if_exists:
+  - README.md
+  - docs/**
 _jinja_extensions:
   - copier_template_extensions.TemplateExtensionLoader
   - python_package_copier_template.extensions:CurrentYearExtension

--- a/docs/about_the_docs.md
+++ b/docs/about_the_docs.md
@@ -39,6 +39,11 @@ The build runs in warning-as-error mode, so broken links or directives are caugh
 - **Any behavior or feature change** should update the relevant doc page in the same PR.
 - **Generated projects should prefer adding new sections** over rewriting seeded ones, to keep `copier update` diffs clean.
 
+Copier treats generated `README.md` and `docs/**` files as project-owned after
+their initial creation. Template updates add missing documentation pages but do
+not overwrite existing ones. Review documentation changes in the template when
+you want to adopt improvements manually.
+
 ## Publishing
 
 GitHub Actions (defined in `.github/workflows/cd.yml`) deploys docs to GitHub Pages automatically:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from python_package_copier_template import cli, extensions
 
 
-def render_from_clean_template(tmp_path: Path, monkeypatch) -> Path:
+def render_from_clean_template(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
     template_src = Path(__file__).resolve().parent.parent
     clean_template = tmp_path / "template-src"
     subprocess.run(["git", "clone", str(template_src), str(clean_template)], check=True)
@@ -22,11 +22,11 @@ def render_from_clean_template(tmp_path: Path, monkeypatch) -> Path:
 
     dest = tmp_path / "proj"
     cli.main([str(dest)])
-    return dest
+    return dest, clean_template
 
 
 def test_cli_copy_and_update(tmp_path: Path, monkeypatch) -> None:
-    dest = render_from_clean_template(tmp_path, monkeypatch)
+    dest, _ = render_from_clean_template(tmp_path, monkeypatch)
     project_exists_on_pypi = False
 
     # First run: copy should create the project (defaults provided via env).
@@ -65,13 +65,55 @@ def test_cli_copy_and_update(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_generated_project_files_do_not_keep_jinja_markers(tmp_path: Path, monkeypatch) -> None:
-    dest = render_from_clean_template(tmp_path, monkeypatch)
+    dest, _ = render_from_clean_template(tmp_path, monkeypatch)
 
     for relative_path in ("README.md", "pyproject.toml", "docs/index.md"):
         text = (dest / relative_path).read_text(encoding="utf-8")
         assert "{{" not in text
         assert "{%" not in text
         assert "%}" not in text
+
+
+def test_update_preserves_existing_docs_and_adds_new_pages(tmp_path: Path, monkeypatch) -> None:
+    dest, clean_template = render_from_clean_template(tmp_path, monkeypatch)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+    readme = dest / "README.md"
+    configuration = dest / "docs/configuration.md"
+    readme.write_text("# Custom project\n", encoding="utf-8")
+    configuration.write_text("# Custom configuration\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-b", "main"], cwd=dest, check=True, env=env)
+    subprocess.run(["git", "add", "."], cwd=dest, check=True, env=env)
+    subprocess.run(["git", "commit", "-m", "customize docs"], cwd=dest, check=True, env=env)
+
+    new_page = clean_template / "project/docs/new_guide.md.jinja"
+    new_page.write_text("# New guide\n", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=clean_template, check=True, env=env)
+    subprocess.run(
+        ["git", "commit", "-m", "add a new documentation page"],
+        cwd=clean_template,
+        check=True,
+        env=env,
+    )
+    with extensions.update_mode():
+        cli.run_update(
+            dst_path=str(dest),
+            defaults=True,
+            unsafe=True,
+            overwrite=True,
+            skip_answered=True,
+            vcs_ref="HEAD",
+        )
+
+    assert readme.read_text(encoding="utf-8") == "# Custom project\n"
+    assert configuration.read_text(encoding="utf-8") == "# Custom configuration\n"
+    assert (dest / "docs/new_guide.md").read_text(encoding="utf-8") == "# New guide\n"
 
 
 def test_prek_task_runs_on_update_even_with_defaults() -> None:


### PR DESCRIPTION
## Summary

- preserve generated `README.md` and existing `docs/**` files during Copier updates
- continue creating documentation pages introduced by newer template versions
- document the project-owned docs behavior and manual reconciliation path
- cover preservation and new-page adoption with an integration test

## Why

Project documentation quickly diverges from the initial scaffold. Treating those
files as template-owned caused large update diffs and risked replacing
project-specific content.

## Validation

- `uv run pytest` (9 passed)
- `uv run --group qa ty check`
- `uv run --group qa ruff check`
- `uv run --group qa ruff format --check`
- `uv run --group docs sphinx-build docs docs/_build/html -b html -W`

Closes #33
