### PR TITLE
feat: attest release artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,12 +34,22 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
+
+      - name: Attest release artifacts on GitHub
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/*
+
+      - name: Generate PEP 740 publish attestations
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+
       - run: uv publish
 
       - name: Refresh demo repository

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,18 +37,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      attestations: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
-
-      - name: Attest release artifacts on GitHub
-        uses: actions/attest@v4
-        with:
-          subject-path: dist/*
 
       - name: Generate PEP 740 publish attestations
         uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6

--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -186,6 +186,37 @@ make bump
 make release
 ```
 
+## Release attestations
+
+Release workflows sign every wheel and source distribution without storing a
+long-lived signing key. GitHub Actions exchanges its OIDC identity for a
+short-lived Sigstore certificate, and the resulting signed statement binds the
+artifact digest to the workflow that produced it.
+
+The workflow produces two complementary records:
+
+- `astral-sh/attest-action` creates
+  [PEP 740](https://peps.python.org/pep-0740/) publish attestations, which
+  `uv publish` uploads with the distributions to PyPI.
+- `actions/attest` records SLSA build provenance in GitHub Artifact
+  Attestations, allowing consumers to verify the files against this repository.
+
+After downloading a wheel or source distribution, verify its GitHub provenance:
+
+```bash
+gh attestation verify path/to/distribution.whl \
+  --repo mgaitan/python-package-copier-template
+```
+
+For offline verification, download the attestation bundle first and pass it
+explicitly:
+
+```bash
+gh attestation verify path/to/distribution.whl \
+  --repo mgaitan/python-package-copier-template \
+  --bundle path/to/attestation.jsonl
+```
+
 ## Repository ergonomics
 
 The template also generates the boring but useful project files early:

--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -193,28 +193,16 @@ long-lived signing key. GitHub Actions exchanges its OIDC identity for a
 short-lived Sigstore certificate, and the resulting signed statement binds the
 artifact digest to the workflow that produced it.
 
-The workflow produces two complementary records:
+`astral-sh/attest-action` creates
+[PEP 740](https://peps.python.org/pep-0740/) publish attestations, which
+`uv publish` uploads with the distributions to PyPI.
 
-- `astral-sh/attest-action` creates
-  [PEP 740](https://peps.python.org/pep-0740/) publish attestations, which
-  `uv publish` uploads with the distributions to PyPI.
-- `actions/attest` records SLSA build provenance in GitHub Artifact
-  Attestations, allowing consumers to verify the files against this repository.
-
-After downloading a wheel or source distribution, verify its GitHub provenance:
+Verify a published wheel or source distribution by passing its PyPI file URL:
 
 ```bash
-gh attestation verify path/to/distribution.whl \
-  --repo mgaitan/python-package-copier-template
-```
-
-For offline verification, download the attestation bundle first and pass it
-explicitly:
-
-```bash
-gh attestation verify path/to/distribution.whl \
-  --repo mgaitan/python-package-copier-template \
-  --bundle path/to/attestation.jsonl
+uvx pypi-attestations verify pypi \
+  --repository https://github.com/mgaitan/python-package-copier-template \
+  https://files.pythonhosted.org/path/to/distribution.whl
 ```
 
 ## Repository ergonomics

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -37,16 +37,10 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
-
-      - name: Attest release artifacts on GitHub
-        uses: actions/attest@v4
-        with:
-          subject-path: dist/*
 
       - name: Generate PEP 740 publish attestations
         uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -34,10 +34,20 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      attestations: write
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
       - run: uv build
+
+      - name: Attest release artifacts on GitHub
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/*
+
+      - name: Generate PEP 740 publish attestations
+        uses: astral-sh/attest-action@f589a42a7efb6fe400b4f400de60b4bc90390027 # v0.0.6
+
       - run: uv publish
 
       - name: Refresh demo repository

--- a/project/docs/development_workflow.md.jinja
+++ b/project/docs/development_workflow.md.jinja
@@ -35,6 +35,27 @@ make release
 
 Release workflows publish package artifacts and canonical docs.
 
+### Verify release attestations
+
+Each wheel and source distribution has signed provenance generated from the
+release workflow. The PEP 740 publish attestation is uploaded to PyPI with the
+package, while GitHub stores SLSA build provenance signed through Sigstore.
+
+After downloading an artifact, verify that it came from this repository:
+
+```bash
+gh attestation verify path/to/distribution.whl \
+  --repo {{ repository_namespace }}/{{ repository_name }}
+```
+
+To verify with an attestation bundle downloaded in advance:
+
+```bash
+gh attestation verify path/to/distribution.whl \
+  --repo {{ repository_namespace }}/{{ repository_name }} \
+  --bundle path/to/attestation.jsonl
+```
+
 ## Preview documentation in pull requests
 
 When docs files change in a PR, CI deploys a preview to:

--- a/project/docs/development_workflow.md.jinja
+++ b/project/docs/development_workflow.md.jinja
@@ -37,23 +37,15 @@ Release workflows publish package artifacts and canonical docs.
 
 ### Verify release attestations
 
-Each wheel and source distribution has signed provenance generated from the
-release workflow. The PEP 740 publish attestation is uploaded to PyPI with the
-package, while GitHub stores SLSA build provenance signed through Sigstore.
+Each wheel and source distribution has a PEP 740 publish attestation signed
+through Sigstore and uploaded to PyPI with the package.
 
-After downloading an artifact, verify that it came from this repository:
-
-```bash
-gh attestation verify path/to/distribution.whl \
-  --repo {{ repository_namespace }}/{{ repository_name }}
-```
-
-To verify with an attestation bundle downloaded in advance:
+Verify a published artifact by passing its PyPI file URL:
 
 ```bash
-gh attestation verify path/to/distribution.whl \
-  --repo {{ repository_namespace }}/{{ repository_name }} \
-  --bundle path/to/attestation.jsonl
+uvx pypi-attestations verify pypi \
+  --repository https://github.com/{{ repository_namespace }}/{{ repository_name }} \
+  https://files.pythonhosted.org/path/to/distribution.whl
 ```
 
 ## Preview documentation in pull requests


### PR DESCRIPTION
## Summary

- generate GitHub SLSA provenance for every wheel and source distribution
- generate PEP 740 publish attestations before `uv publish`
- grant the release job the scoped `attestations: write` permission
- apply the release hardening to both this package and generated projects
- document Sigstore, PEP 740, GitHub Artifact Attestations, and online/offline verification

## Why

Release consumers should be able to verify that downloaded distributions were
produced by the expected GitHub Actions workflow and were not modified after the
build.

## Validation

- `uv run pytest` (8 passed)
- `uv run --group qa ty check`
- `uv run --group qa ruff check`
- `uv run --group qa ruff format --check`
- template documentation built with warnings as errors
- rendered-project prek/Ruff/ty checks and documentation build
- generated workflow inspected after Copier rendering

`actionlint` was not available locally; CI performs workflow linting.

Closes #58
