### PR TITLE
feat: enable immutable releases for new repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,11 @@ uv sync
 uv run copier copy --trust  --vcs-ref=HEAD . /path/to/your/test/project
 ```
 
-If you create the GitHub repository via the `gh` CLI prompt, the template will attempt to enable GitHub Pages (using the Actions build type) so documentation deployments succeed. If Pages is unavailable (for example, with some private repositories or account policies), the docs workflow will keep failing until Pages is allowed.
+If you create the GitHub repository via the `gh` CLI prompt, the template will
+attempt to enable immutable releases and GitHub Pages (using the Actions build
+type). Immutability protects assets and tags for future releases. If Pages is
+unavailable (for example, with some private repositories or account policies),
+the docs workflow will keep failing until Pages is allowed.
 
 
 To publish a release of your project to PyPI, you need to [register the project with trusted publishing](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/). Read more about how this workflow works [here](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/).

--- a/copier.yml
+++ b/copier.yml
@@ -43,6 +43,15 @@ _tasks:
         fi
         git push -u origin main
         gh repo edit "$repo" --enable-wiki=false --enable-projects=false >/dev/null 2>&1 || true
+        if gh api \
+          --method PUT \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2026-03-10" \
+          "repos/${repo}/immutable-releases" >/dev/null 2>&1; then
+          echo "Immutable releases enabled for ${repo}"
+        else
+          echo "Warning: could not enable immutable releases for ${repo}." >&2
+        fi
         # Enable Pages for workflow builds (required by deploy-pages).
         if gh api \
           --method POST \

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -113,6 +113,8 @@ That uses the local repository as the template source and resolves updates again
 
 If you choose GitHub repository creation during the questionnaire and have `gh` available, the template can bootstrap the repository for you.
 For public repositories, it also tries to enable GitHub Pages so the generated docs workflow can publish without extra manual setup.
+It also enables immutable releases, which prevents assets and tags from being
+changed after future releases are published. Existing releases are unaffected.
 
 For PyPI publishing in generated projects, the release workflow is based on [Trusted Publishing](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/).
 That still requires one manual registration step in PyPI for the project and workflow identity.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -85,6 +85,14 @@ def test_prek_task_runs_on_update_even_with_defaults() -> None:
     assert expected_when in content
 
 
+def test_github_setup_enables_immutable_releases() -> None:
+    copier_yml = Path(__file__).resolve().parent.parent / "copier.yml"
+    content = copier_yml.read_text(encoding="utf-8")
+
+    assert '"X-GitHub-Api-Version: 2026-03-10"' in content
+    assert '"repos/${repo}/immutable-releases"' in content
+
+
 def test_resolve_template_target_uses_package_version_for_registry_installs(monkeypatch) -> None:
     class _DummyDistribution:
         version = "0.4.2"


### PR DESCRIPTION
## Summary

- enable immutable releases when Copier creates a GitHub repository
- use the GitHub REST endpoint through `gh api` with the current API version
- keep setup non-blocking and emit a warning when account policy prevents it
- document that immutability protects future release assets and tags
- cover the endpoint and API version in the template tests

## Why

Immutable releases prevent published assets from being replaced and their tags
from being moved, reducing release supply-chain risk.

## Validation

- enabled immutable releases for `mgaitan/python-package-copier-template` and confirmed `enabled: true`
- `uv run pytest` (9 passed)
- `uv run --group qa ty check`
- `uv run --group qa ruff check`
- `uv run --group qa ruff format --check`
- template documentation built with warnings as errors
- Copier default scaffold rendered successfully

Closes #73
