### PR TITLE
feat: enable uv malware checks

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,6 +26,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  UV_MALWARE_CHECK: "1"
+
 jobs:
   pypi-publish:
     name: upload release to PyPI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+env:
+  UV_MALWARE_CHECK: "1"
+
 jobs:
   smoke:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 .PHONY: install lint format test qa bump release docs docs-open smoke help
 
+export UV_MALWARE_CHECK := 1
+
 DOCS_SOURCE := docs
 DOCS_BUILD := $(DOCS_SOURCE)/_build
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Documentation: <https://mgaitan.github.io/python-package-copier-template/>
 - 🐍 Modern Python package (3.12+)
 - 📦 Build and dependency management with [uv](https://docs.astral.sh/uv/), split by groups (dev/qa/docs)
 - 🧊 Dependency cooldowns enabled by default in `uv` (`[tool.uv].exclude-newer = "1 week"`), with targeted overrides when needed (for example `ty`) to reduce supply-chain risk without blocking QA tools
+- 🛡️ uv malware checks enabled in Make targets and GitHub Actions to reject locked dependencies with known malicious-package advisories
 - 🧹 Linting and formatting via [Ruff](https://docs.astral.sh/ruff/) with a broad set of rules enabled
 - ✅ Type checking via [ty](https://github.com/astral-sh/ty)
 - 🪝 Optional pre-commit style QA orchestration via [prek](https://github.com/j178/prek) as an external tool (`uv tool install prek`; hooks include `check-ast`, `check-yaml`, `check-toml`, Ruff, Ty)

--- a/copier.yml
+++ b/copier.yml
@@ -18,7 +18,7 @@ _tasks:
   - when: "{{ (not (defaults | default(false))) and (not '.git' | path_exists) }}"
     command: uv python pin 3.14
   - when: "{{ (not (defaults | default(false))) and (not '.git' | path_exists) }}"
-    command: uv sync
+    command: UV_MALWARE_CHECK=1 uv sync
   - when: "{{ (not (defaults | default(false))) and (not '.git' | path_exists) }}"
     command: git init -b main
   - when: "{{ (not (defaults | default(false))) and (not '.git' | path_exists) }}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,10 @@ GITHUB_TOKEN
   Ephemeral token automatically provided by GitHub Actions.
   Its effective permissions are controlled by workflow/job `permissions` blocks.
 
+UV_MALWARE_CHECK
+  Enables uv's preview lockfile scan against malicious-package advisories from OSV.
+  Make targets and GitHub Actions set it to `1`, causing syncs to stop when a locked dependency matches a known malware advisory.
+
 DEMO_REPO_TOKEN
   Repository secret used by this template repository's release workflow to push updates to the demo repository `mgaitan/yet-another-demo`.
   Use a fine-grained token with `Contents: Read and write` on that repository.

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -26,6 +26,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  UV_MALWARE_CHECK: "1"
+
 jobs:
   pypi-publish:
     name: upload release to PyPI

--- a/project/.github/workflows/ci.yml.jinja
+++ b/project/.github/workflows/ci.yml.jinja
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+env:
+  UV_MALWARE_CHECK: "1"
+
 jobs:
   workflows-lint:
     runs-on: ubuntu-latest

--- a/project/.github/workflows/template-update.yml.jinja
+++ b/project/.github/workflows/template-update.yml.jinja
@@ -5,6 +5,9 @@ on:
     - cron: "0 0 */20 * *"
   workflow_dispatch:
 
+env:
+  UV_MALWARE_CHECK: "1"
+
 permissions:
   contents: write
   pull-requests: write

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -1,4 +1,6 @@
 .PHONY: install
+export UV_MALWARE_CHECK := 1
+
 install: ## Install the virtual environment and install the pre-commit hooks
 	@echo "🚀 Creating virtual environment using uv"
 	@uv sync

--- a/project/README.md.jinja
+++ b/project/README.md.jinja
@@ -32,6 +32,7 @@ uv tool install {{ python_package_distribution_name }}
 
 - Install dependencies with `uv sync`.
 - New dependency releases are delayed by one week via `uv` cooldown (`[tool.uv].exclude-newer = "1 week"`), with per-package overrides when required (for example, `ty`).
+- Make targets and GitHub Actions enable uv's malware check against known malicious-package advisories.
 - Install [`prek`](https://github.com/j178/prek) as an external tool:
 
 ```bash

--- a/project/docs/configuration.md.jinja
+++ b/project/docs/configuration.md.jinja
@@ -16,6 +16,10 @@ GITHUB_TOKEN
   Ephemeral token automatically injected by GitHub Actions jobs.
   Used by workflows to interact with repository APIs with job-scoped permissions.
 
+UV_MALWARE_CHECK
+  Enables uv's preview lockfile scan against malicious-package advisories from OSV.
+  Make targets and GitHub Actions set it to `1`, causing syncs to stop when a locked dependency matches a known malware advisory.
+
 NO_COLOR
   De-facto standard variable used by CLI tools to disable ANSI colors.
   Prefer this for plain-text logs where color escape sequences are undesirable.


### PR DESCRIPTION
## Summary

- enable uv's OSV-backed malware check in template and generated-project Make targets
- enable the check across template, CI, CD, and scheduled update workflows
- protect the initial `uv sync` performed by Copier
- document `UV_MALWARE_CHECK` in both environment-variable glossaries
- surface the protection in template and generated-project feature lists

## Why

uv can stop dependency synchronization when a locked package matches a known
malicious-package advisory. Enabling the preview check adds that safeguard to
the installation paths maintained by this template.

## Validation

- `make qa` (including 8 tests and warning-as-error docs build)
- rendered the default Copier scaffold
- generated-project prek/Ruff/ty checks
- generated-project documentation build
- confirmed all three generated workflows contain `UV_MALWARE_CHECK: "1"`

Closes #74
