### PR TITLE
chore: expand Ruff lint rules

### DIFF
--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -114,6 +114,20 @@ That tradeoff keeps projects conservative by default while preserving room to ad
 [Ruff](https://docs.astral.sh/ruff/) is the linting and formatting baseline.
 The main value here is consolidation: a single fast tool can cover what used to require multiple linters and formatters, which makes local feedback and CI simpler.
 
+The selected rules are deliberately a superset of
+[Ruff's default rules](https://docs.astral.sh/ruff/rules/#default-rules).
+The configuration keeps `E` and `F`, which include the default `E4`, `E7`,
+`E9`, and `F` checks, then adds the broader correctness, security, naming,
+logging, modernization, testing, and documentation families listed in
+`pyproject.toml`. A regression test protects the required selectors in both
+this package and the generated project template.
+
+Specific per-file ignores remain narrow: test modules may use assertions and
+fixture-oriented patterns, while Sphinx configuration files are not required
+to behave like public Python modules. The incompatible pydocstyle pairs
+`D203`/`D211` and `D212`/`D213` are resolved explicitly in favor of `D211` and
+`D212`.
+
 ## ty for type checking
 
 [ty](https://github.com/astral-sh/ty) is the default type checker.

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -45,42 +45,53 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",      # Includes Ruff's default E4, E7, and E9 rules
-    "W",      # pycodestyle (E, W) https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
-    "F",      # Pyflakes and the remaining Ruff defaults
-    "I",      # isort
+    "E",      # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "W",      # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "F",      # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I",      # https://docs.astral.sh/ruff/rules/#isort-i
     "C90",    # https://docs.astral.sh/ruff/rules/#mccabe-c90
     "A",      # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
     "ANN",    # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
     "UP",     # https://docs.astral.sh/ruff/rules/#pyupgrade-up
     "RUF",    # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
-    "T10",    # remove pdbs
+    "T10",    # https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
     "ISC",    # https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc
     "SIM",    # https://docs.astral.sh/ruff/rules/#flake8-simplify-sim
     "ASYNC",  # https://docs.astral.sh/ruff/rules/#flake8-async-async
     "ERA",    # https://docs.astral.sh/ruff/rules/#eradicate-era
     "TRY",    # https://docs.astral.sh/ruff/rules/#tryceratops-try
+    "YTT",    # https://docs.astral.sh/ruff/rules/#flake8-2020-ytt
     "BLE",    # https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble
     "B",      # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
     "EXE",    # https://docs.astral.sh/ruff/rules/#flake8-executable-exe
     "FA",     # https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa
     "C4",     # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "DTZ",    # https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz
     "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
+    "INT",    # https://docs.astral.sh/ruff/rules/#flake8-gettext-int
+    "LOG",    # https://docs.astral.sh/ruff/rules/#flake8-logging-log
     "S",      # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
     "G",      # https://docs.astral.sh/ruff/rules/#flake8-logging-format-g
     "FLY",    # https://docs.astral.sh/ruff/rules/#flynt-fly
     "N",      # https://docs.astral.sh/ruff/rules/#pep8-naming-n
     "PIE",    # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
+    "PYI",    # https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi
+    "PT",     # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
+    "TC",     # https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc
+    "PTH",    # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
     "PERF",   # https://docs.astral.sh/ruff/rules/#perflint-perf
+    "D",      # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "PGH",    # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
     "PL",     # https://docs.astral.sh/ruff/rules/#pylint-pl
     "FURB",   # https://docs.astral.sh/ruff/rules/#refurb-furb
     "RET",    # https://docs.astral.sh/ruff/rules/#flake8-return-ret
     "TID252", # https://docs.astral.sh/ruff/rules/relative-imports/
 ]
+ignore = ["D203", "D213"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN", "S101"]
-"docs/conf.py" = ["A"]
+"tests/**/*.py" = ["ANN", "D", "S101"]
+"docs/conf.py" = ["A", "D100"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/project/pyproject.toml.jinja
+++ b/project/pyproject.toml.jinja
@@ -45,9 +45,9 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",
+    "E",      # Includes Ruff's default E4, E7, and E9 rules
     "W",      # pycodestyle (E, W) https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
-    "F",      # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "F",      # Pyflakes and the remaining Ruff defaults
     "I",      # isort
     "C90",    # https://docs.astral.sh/ruff/rules/#mccabe-c90
     "A",      # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
@@ -65,6 +65,10 @@ select = [
     "EXE",    # https://docs.astral.sh/ruff/rules/#flake8-executable-exe
     "FA",     # https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa
     "C4",     # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
+    "S",      # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    "G",      # https://docs.astral.sh/ruff/rules/#flake8-logging-format-g
+    "FLY",    # https://docs.astral.sh/ruff/rules/#flynt-fly
     "N",      # https://docs.astral.sh/ruff/rules/#pep8-naming-n
     "PIE",    # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
     "PERF",   # https://docs.astral.sh/ruff/rules/#perflint-perf
@@ -75,7 +79,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN"]
+"tests/**/*.py" = ["ANN", "S101"]
 "docs/conf.py" = ["A"]
 
 [tool.pytest.ini_options]

--- a/project/src/{{python_package_import_name}}/__init__.py.jinja
+++ b/project/src/{{python_package_import_name}}/__init__.py.jinja
@@ -1,5 +1,4 @@
-"""
-{{ project_name }}
+"""{{ project_name }}.
 
 {{ project_description }}
 """
@@ -10,6 +9,7 @@ from importlib import metadata
 
 
 def get_version() -> str:
+    """Return the installed package version."""
     try:
         return metadata.version("{{ python_package_distribution_name }}")
     except metadata.PackageNotFoundError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,42 +30,53 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",      # Includes Ruff's default E4, E7, and E9 rules
-    "W",      # pycodestyle
-    "F",      # Pyflakes and the remaining Ruff defaults
-    "I",      # isort
-    "C90",    # mccabe
-    "A",      # flake8-builtins
-    "ANN",    # flake8-annotations
-    "UP",     # pyupgrade
-    "RUF",    # Ruff-specific rules
-    "T10",    # flake8-debugger
-    "ISC",    # flake8-implicit-str-concat
-    "SIM",    # flake8-simplify
-    "ASYNC",  # flake8-async
-    "ERA",    # eradicate
-    "TRY",    # tryceratops
-    "BLE",    # flake8-blind-except
-    "B",      # flake8-bugbear
-    "EXE",    # flake8-executable
-    "FA",     # flake8-future-annotations
-    "C4",     # flake8-comprehensions
-    "FBT",    # flake8-boolean-trap
-    "S",      # flake8-bandit
-    "G",      # flake8-logging-format
-    "FLY",    # flynt
-    "N",      # pep8-naming
-    "PIE",    # flake8-pie
-    "PERF",   # Perflint
-    "PL",     # Pylint
-    "FURB",   # refurb
-    "RET",    # flake8-return
-    "TID252", # flake8-tidy-imports
+    "E",      # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "W",      # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "F",      # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "I",      # https://docs.astral.sh/ruff/rules/#isort-i
+    "C90",    # https://docs.astral.sh/ruff/rules/#mccabe-c90
+    "A",      # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "ANN",    # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "UP",     # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "RUF",    # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+    "T10",    # https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
+    "ISC",    # https://docs.astral.sh/ruff/rules/#flake8-implicit-str-concat-isc
+    "SIM",    # https://docs.astral.sh/ruff/rules/#flake8-simplify-sim
+    "ASYNC",  # https://docs.astral.sh/ruff/rules/#flake8-async-async
+    "ERA",    # https://docs.astral.sh/ruff/rules/#eradicate-era
+    "TRY",    # https://docs.astral.sh/ruff/rules/#tryceratops-try
+    "YTT",    # https://docs.astral.sh/ruff/rules/#flake8-2020-ytt
+    "BLE",    # https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble
+    "B",      # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "EXE",    # https://docs.astral.sh/ruff/rules/#flake8-executable-exe
+    "FA",     # https://docs.astral.sh/ruff/rules/#flake8-future-annotations-fa
+    "C4",     # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "DTZ",    # https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz
+    "FBT",    # https://docs.astral.sh/ruff/rules/#flake8-boolean-trap-fbt
+    "INT",    # https://docs.astral.sh/ruff/rules/#flake8-gettext-int
+    "LOG",    # https://docs.astral.sh/ruff/rules/#flake8-logging-log
+    "S",      # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    "G",      # https://docs.astral.sh/ruff/rules/#flake8-logging-format-g
+    "FLY",    # https://docs.astral.sh/ruff/rules/#flynt-fly
+    "N",      # https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "PIE",    # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
+    "PYI",    # https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi
+    "PT",     # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
+    "TC",     # https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc
+    "PTH",    # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "PERF",   # https://docs.astral.sh/ruff/rules/#perflint-perf
+    "D",      # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "PGH",    # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
+    "PL",     # https://docs.astral.sh/ruff/rules/#pylint-pl
+    "FURB",   # https://docs.astral.sh/ruff/rules/#refurb-furb
+    "RET",    # https://docs.astral.sh/ruff/rules/#flake8-return-ret
+    "TID252", # https://docs.astral.sh/ruff/rules/relative-imports/
 ]
+ignore = ["D203", "D213"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["ANN", "S101", "S108", "S603", "S607"]
-"docs/conf.py" = ["A"]
+"tests/**/*.py" = ["ANN", "D", "S101", "S108", "S603", "S607"]
+"docs/conf.py" = ["A", "D100"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,45 @@ exclude = [".worktrees/", ".external-worktrees/"]
 [tool.ruff]
 line-length = 120
 
+[tool.ruff.lint]
+select = [
+    "E",      # Includes Ruff's default E4, E7, and E9 rules
+    "W",      # pycodestyle
+    "F",      # Pyflakes and the remaining Ruff defaults
+    "I",      # isort
+    "C90",    # mccabe
+    "A",      # flake8-builtins
+    "ANN",    # flake8-annotations
+    "UP",     # pyupgrade
+    "RUF",    # Ruff-specific rules
+    "T10",    # flake8-debugger
+    "ISC",    # flake8-implicit-str-concat
+    "SIM",    # flake8-simplify
+    "ASYNC",  # flake8-async
+    "ERA",    # eradicate
+    "TRY",    # tryceratops
+    "BLE",    # flake8-blind-except
+    "B",      # flake8-bugbear
+    "EXE",    # flake8-executable
+    "FA",     # flake8-future-annotations
+    "C4",     # flake8-comprehensions
+    "FBT",    # flake8-boolean-trap
+    "S",      # flake8-bandit
+    "G",      # flake8-logging-format
+    "FLY",    # flynt
+    "N",      # pep8-naming
+    "PIE",    # flake8-pie
+    "PERF",   # Perflint
+    "PL",     # Pylint
+    "FURB",   # refurb
+    "RET",    # flake8-return
+    "TID252", # flake8-tidy-imports
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["ANN", "S101", "S108", "S603", "S607"]
+"docs/conf.py" = ["A"]
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",

--- a/python_package_copier_template/__init__.py
+++ b/python_package_copier_template/__init__.py
@@ -1,3 +1,5 @@
+"""Public package interface."""
+
 from .cli import main
 
 __all__ = ["main"]

--- a/python_package_copier_template/cli.py
+++ b/python_package_copier_template/cli.py
@@ -1,3 +1,5 @@
+"""Command-line wrapper for copying and updating projects."""
+
 import argparse
 import json
 import os
@@ -18,11 +20,14 @@ ANSWER_FILES: tuple[str, ...] = (".copier-answers.yml", ".copier-answers.yaml")
 
 @dataclass(frozen=True)
 class TemplateTarget:
+    """Template source and optional version control reference."""
+
     src_path: str
     vcs_ref: str | None = None
 
 
 def get_version() -> str:
+    """Return the installed package version."""
     try:
         return version("python-package-copier-template")
     except PackageNotFoundError:
@@ -30,10 +35,12 @@ def get_version() -> str:
 
 
 def has_answers(dst: Path) -> bool:
+    """Return whether a destination contains Copier answers."""
     return any((dst / filename).exists() for filename in ANSWER_FILES)
 
 
 def get_local_git_head(path: str) -> str | None:
+    """Return the current commit for a local Git repository."""
     if not (git := shutil.which("git")):
         return None
 
@@ -51,6 +58,7 @@ def get_local_git_head(path: str) -> str | None:
 
 
 def resolve_template_target() -> TemplateTarget:
+    """Resolve the template source matching the installed package."""
     try:
         dist = distribution("python-package-copier-template")
     except PackageNotFoundError:
@@ -76,6 +84,7 @@ def resolve_template_target() -> TemplateTarget:
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Build the package command-line parser."""
     parser = argparse.ArgumentParser(
         prog="python-package-copier-template",
         description=(
@@ -93,6 +102,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Copy or update a project based on its Copier answers file."""
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/python_package_copier_template/cli.py
+++ b/python_package_copier_template/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import json
 import os
+import shutil
 import subprocess
 from dataclasses import dataclass
 from importlib.metadata import PackageNotFoundError, distribution, version
@@ -33,9 +34,12 @@ def has_answers(dst: Path) -> bool:
 
 
 def get_local_git_head(path: str) -> str | None:
+    if not (git := shutil.which("git")):
+        return None
+
     try:
-        result = subprocess.run(
-            ["git", "-C", path, "rev-parse", "HEAD"],
+        result = subprocess.run(  # noqa: S603 - arguments are passed without a shell
+            [git, "-C", path, "rev-parse", "HEAD"],
             check=True,
             capture_output=True,
             text=True,

--- a/python_package_copier_template/extensions.py
+++ b/python_package_copier_template/extensions.py
@@ -1,3 +1,5 @@
+"""Jinja extensions and filters used while rendering the template."""
+
 import re
 import shutil
 import subprocess
@@ -7,7 +9,7 @@ import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from datetime import date
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import cast
 
@@ -21,7 +23,6 @@ MAX_PYPI_SUFFIX = 50
 @contextmanager
 def update_mode() -> Iterator[None]:
     """Mark the current execution context as an update operation."""
-
     token = _UPDATE_MODE.set(True)
     try:
         yield
@@ -30,10 +31,12 @@ def update_mode() -> Iterator[None]:
 
 
 def git_user_name(default: str) -> str:
+    """Return the configured Git author name or a fallback."""
     return _git_config_value("user.name", default)
 
 
 def git_user_email(default: str) -> str:
+    """Return the configured Git author email or a fallback."""
     return _git_config_value("user.email", default)
 
 
@@ -56,7 +59,6 @@ def _git_config_value(key: str, default: str) -> str:
 
 def gh_user_login(default: str) -> str:
     """Return the authenticated GitHub username via the GH CLI when available."""
-
     if not (gh := shutil.which("gh")):
         return default
 
@@ -78,11 +80,11 @@ def gh_user_login(default: str) -> str:
 
 def command_available(command: str) -> bool:
     """Return True if the command exists on PATH."""
-
     return shutil.which(command) is not None
 
 
 def slugify(value: object, separator: str = "-") -> str:
+    """Normalize a value for use in package and repository names."""
     value = unicodedata.normalize("NFKD", str(value)).encode("ascii", "ignore").decode("ascii")
     value = re.sub(r"[^\w\s-]", "", value.lower())
     return re.sub(r"[-_\s]+", separator, value).strip("-_")
@@ -90,13 +92,11 @@ def slugify(value: object, separator: str = "-") -> str:
 
 def path_exists(path: str) -> bool:
     """Return True when ``path`` exists relative to the destination."""
-
     return Path(path).expanduser().exists()
 
 
 def is_update(defaults: bool | None = None) -> bool:  # noqa: FBT001 - Jinja filters receive positional values
     """Return True when running under `copier update`."""
-
     return bool(defaults)
 
 
@@ -106,7 +106,6 @@ def pypi_distribution_exists(name: str) -> bool:
     Uses the lightweight JSON endpoint and handles network failures gracefully
     by treating them as "not found" so template execution is not blocked.
     """
-
     # During updates we keep the previously selected distribution name and
     # should not block on global PyPI availability checks.
     if _UPDATE_MODE.get():
@@ -126,21 +125,23 @@ def pypi_distribution_exists(name: str) -> bool:
 
 def suggest_pypi_distribution_name(name: str) -> str:
     """Return a PyPI-safe distribution name, adding a suffix if needed."""
-
     base = slugify(name)
     if not base:
         base = "package"
 
     candidate = base
-    suffix = 1
-    while pypi_distribution_exists(candidate) and suffix < MAX_PYPI_SUFFIX:
+    for suffix in range(1, MAX_PYPI_SUFFIX + 1):
+        if not pypi_distribution_exists(candidate):
+            return candidate
         candidate = f"{base}-{suffix}"
-        suffix += 1
     return candidate
 
 
 class GitExtension(Extension):
+    """Register Git, GitHub, command, and path filters."""
+
     def __init__(self, environment: Environment) -> None:
+        """Register filters in a Jinja environment."""
         super().__init__(environment)
         environment.filters["git_user_name"] = git_user_name
         environment.filters["git_user_email"] = git_user_email
@@ -151,7 +152,10 @@ class GitExtension(Extension):
 
 
 class SlugifyExtension(Extension):
+    """Register slug and PyPI name filters."""
+
     def __init__(self, environment: Environment) -> None:
+        """Register filters in a Jinja environment."""
         super().__init__(environment)
         environment.filters["slugify"] = slugify
         environment.filters["pypi_exists"] = pypi_distribution_exists
@@ -159,6 +163,9 @@ class SlugifyExtension(Extension):
 
 
 class CurrentYearExtension(Extension):
+    """Expose the current UTC year to templates."""
+
     def __init__(self, environment: Environment) -> None:
+        """Register the current year in a Jinja environment."""
         super().__init__(environment)
-        cast("dict[str, object]", environment.globals)["current_year"] = date.today().year
+        cast("dict[str, object]", environment.globals)["current_year"] = datetime.now(tz=UTC).year

--- a/python_package_copier_template/extensions.py
+++ b/python_package_copier_template/extensions.py
@@ -4,18 +4,22 @@ import subprocess
 import unicodedata
 import urllib.error
 import urllib.request
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import date
 from pathlib import Path
+from typing import cast
 
+from jinja2 import Environment
 from jinja2.ext import Extension
 
 _UPDATE_MODE: ContextVar[bool] = ContextVar("copier_template_update_mode", default=False)
+MAX_PYPI_SUFFIX = 50
 
 
 @contextmanager
-def update_mode():
+def update_mode() -> Iterator[None]:
     """Mark the current execution context as an update operation."""
 
     token = _UPDATE_MODE.set(True)
@@ -26,19 +30,39 @@ def update_mode():
 
 
 def git_user_name(default: str) -> str:
-    return subprocess.getoutput("git config user.name").strip() or default
+    return _git_config_value("user.name", default)
 
 
 def git_user_email(default: str) -> str:
-    return subprocess.getoutput("git config user.email").strip() or default
+    return _git_config_value("user.email", default)
+
+
+def _git_config_value(key: str, default: str) -> str:
+    if not (git := shutil.which("git")):
+        return default
+
+    try:
+        completed = subprocess.run(  # noqa: S603 - arguments are passed without a shell
+            [git, "config", key],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return default
+
+    return completed.stdout.strip() or default
 
 
 def gh_user_login(default: str) -> str:
     """Return the authenticated GitHub username via the GH CLI when available."""
 
+    if not (gh := shutil.which("gh")):
+        return default
+
     try:
-        completed = subprocess.run(
-            ["gh", "api", "user", "-q", ".login"],
+        completed = subprocess.run(  # noqa: S603 - arguments are passed without a shell
+            [gh, "api", "user", "-q", ".login"],
             check=True,
             capture_output=True,
             text=True,
@@ -46,7 +70,7 @@ def gh_user_login(default: str) -> str:
         login = completed.stdout.strip()
         if login:
             return login
-    except (FileNotFoundError, subprocess.CalledProcessError):
+    except subprocess.CalledProcessError:
         return default
 
     return default
@@ -58,7 +82,7 @@ def command_available(command: str) -> bool:
     return shutil.which(command) is not None
 
 
-def slugify(value, separator="-"):
+def slugify(value: object, separator: str = "-") -> str:
     value = unicodedata.normalize("NFKD", str(value)).encode("ascii", "ignore").decode("ascii")
     value = re.sub(r"[^\w\s-]", "", value.lower())
     return re.sub(r"[-_\s]+", separator, value).strip("-_")
@@ -70,7 +94,7 @@ def path_exists(path: str) -> bool:
     return Path(path).expanduser().exists()
 
 
-def is_update(defaults: bool | None = None) -> bool:
+def is_update(defaults: bool | None = None) -> bool:  # noqa: FBT001 - Jinja filters receive positional values
     """Return True when running under `copier update`."""
 
     return bool(defaults)
@@ -92,9 +116,9 @@ def pypi_distribution_exists(name: str) -> bool:
         return False
 
     url = f"https://pypi.org/pypi/{name}/json"
-    request = urllib.request.Request(url, method="HEAD")
+    request = urllib.request.Request(url, method="HEAD")  # noqa: S310 - URL is a fixed HTTPS PyPI endpoint
     try:
-        with urllib.request.urlopen(request, timeout=3):
+        with urllib.request.urlopen(request, timeout=3):  # noqa: S310 - request URL is restricted above
             return True
     except (urllib.error.HTTPError, OSError):
         return False
@@ -109,14 +133,14 @@ def suggest_pypi_distribution_name(name: str) -> str:
 
     candidate = base
     suffix = 1
-    while pypi_distribution_exists(candidate) and suffix < 50:
+    while pypi_distribution_exists(candidate) and suffix < MAX_PYPI_SUFFIX:
         candidate = f"{base}-{suffix}"
         suffix += 1
     return candidate
 
 
 class GitExtension(Extension):
-    def __init__(self, environment):
+    def __init__(self, environment: Environment) -> None:
         super().__init__(environment)
         environment.filters["git_user_name"] = git_user_name
         environment.filters["git_user_email"] = git_user_email
@@ -127,7 +151,7 @@ class GitExtension(Extension):
 
 
 class SlugifyExtension(Extension):
-    def __init__(self, environment):
+    def __init__(self, environment: Environment) -> None:
         super().__init__(environment)
         environment.filters["slugify"] = slugify
         environment.filters["pypi_exists"] = pypi_distribution_exists
@@ -135,6 +159,6 @@ class SlugifyExtension(Extension):
 
 
 class CurrentYearExtension(Extension):
-    def __init__(self, environment):
+    def __init__(self, environment: Environment) -> None:
         super().__init__(environment)
-        environment.globals["current_year"] = date.today().year
+        cast("dict[str, object]", environment.globals)["current_year"] = date.today().year

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,14 @@
 import os
 import subprocess
+import tomllib
 import urllib.error
 from email.message import Message
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 from python_package_copier_template import cli, extensions
+
+REQUIRED_RUFF_SELECTORS = {"E", "F", "FBT", "S", "G", "FLY", "N"}
 
 
 def render_from_clean_template(tmp_path: Path, monkeypatch) -> Path:
@@ -37,7 +40,7 @@ def test_cli_copy_and_update(tmp_path: Path, monkeypatch) -> None:
         def __exit__(self, exc_type, exc, tb):
             return False
 
-    def _fake_urlopen(_request, timeout):  # noqa: ANN001
+    def _fake_urlopen(_request, timeout):
         if project_exists_on_pypi:
             return _DummyResponse()
         raise urllib.error.HTTPError("", 404, "not found", Message(), None)
@@ -72,6 +75,16 @@ def test_generated_project_files_do_not_keep_jinja_markers(tmp_path: Path, monke
         assert "{{" not in text
         assert "{%" not in text
         assert "%}" not in text
+
+
+def test_ruff_rules_include_defaults_and_requested_families() -> None:
+    template_root = Path(__file__).resolve().parent.parent
+    root_config = tomllib.loads((template_root / "pyproject.toml").read_text(encoding="utf-8"))
+    assert set(root_config["tool"]["ruff"]["lint"]["select"]) >= REQUIRED_RUFF_SELECTORS
+
+    generated_template = (template_root / "project/pyproject.toml.jinja").read_text(encoding="utf-8")
+    for selector in REQUIRED_RUFF_SELECTORS:
+        assert f'"{selector}"' in generated_template
 
 
 def test_prek_task_runs_on_update_even_with_defaults() -> None:
@@ -158,7 +171,7 @@ def test_resolve_template_target_falls_back_to_plain_path_for_non_git_file_insta
 
 
 def test_resolve_template_target_falls_back_when_distribution_missing(monkeypatch) -> None:
-    def _raise(_name: str):  # noqa: ANN001
+    def _raise(_name: str):
         raise PackageNotFoundError
 
     monkeypatch.setattr(cli, "distribution", _raise)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,25 @@ from pathlib import Path
 
 from python_package_copier_template import cli, extensions
 
-REQUIRED_RUFF_SELECTORS = {"E", "F", "FBT", "S", "G", "FLY", "N"}
+REQUIRED_RUFF_SELECTORS = {
+    "E",
+    "F",
+    "FBT",
+    "S",
+    "G",
+    "FLY",
+    "N",
+    "YTT",
+    "DTZ",
+    "INT",
+    "LOG",
+    "PYI",
+    "PT",
+    "TC",
+    "PTH",
+    "D",
+    "PGH",
+}
 
 
 def render_from_clean_template(tmp_path: Path, monkeypatch) -> tuple[Path, Path]:
@@ -138,6 +156,20 @@ def test_prek_task_runs_on_update_even_with_defaults() -> None:
         "or (_copier_operation == 'update')) and ('prek' | command_available)) }}"
     )
     assert expected_when in content
+
+
+def test_pypi_suggestion_does_not_return_a_known_existing_name(monkeypatch) -> None:
+    checked: list[str] = []
+
+    def exists(name: str) -> bool:
+        checked.append(name)
+        return True
+
+    monkeypatch.setattr(extensions, "MAX_PYPI_SUFFIX", 3)
+    monkeypatch.setattr(extensions, "pypi_distribution_exists", exists)
+
+    assert extensions.suggest_pypi_distribution_name("package") == "package-3"
+    assert checked == ["package", "package-1", "package-2"]
 
 
 def test_github_setup_enables_immutable_releases() -> None:


### PR DESCRIPTION
## Summary

- align Ruff configuration across the template package and generated projects
- enable FBT, S, G, FLY, and N rule families
- retain E and F selectors as an explicit superset of Ruff's default rules
- add regression coverage for required selectors in both configurations
- fix newly exposed annotations, subprocess handling, URL-audit annotations, and a magic value
- keep test-only security exceptions scoped to test files

## Why

The template package previously relied on Ruff defaults while generated projects
used a broader configuration. Explicit aligned selectors make lint coverage
predictable and add the requested correctness, security, logging, modernization,
and naming checks.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest` (9 passed)
- rendered-project prek/Ruff/ty checks
- rendered-project tests (5 passed, 100% coverage)
- rendered-project documentation build with warnings as errors

Closes #77
