### PR TITLE
Pin generated projects to Copier's Python version

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -10,16 +10,16 @@ _exclude:
   - "{% if not ('prek' | command_available) %}prek.toml{% endif %}"
   - "{% if copyright_license == 'none' %}LICENSE{% endif %}"
 _skip_if_exists:
+  - .python-version
   - README.md
   - docs/**
 _jinja_extensions:
   - copier_template_extensions.TemplateExtensionLoader
   - python_package_copier_template.extensions:CurrentYearExtension
   - python_package_copier_template.extensions:GitExtension
+  - python_package_copier_template.extensions:PythonVersionExtension
   - python_package_copier_template.extensions:SlugifyExtension
 _tasks:
-  - when: "{{ (not (defaults | default(false))) and (not '.git' | path_exists) }}"
-    command: uv python pin 3.14
   - when: "{{ (not (defaults | default(false))) and (not '.git' | path_exists) }}"
     command: UV_MALWARE_CHECK=1 uv sync
   - when: "{{ (not (defaults | default(false))) and (not '.git' | path_exists) }}"

--- a/project/.python-version.jinja
+++ b/project/.python-version.jinja
@@ -1,0 +1,1 @@
+{{ python_version }}

--- a/project/docs/development_workflow.md.jinja
+++ b/project/docs/development_workflow.md.jinja
@@ -2,6 +2,11 @@
 
 This guide covers the most common maintenance tasks.
 
+## Use the pinned Python
+
+The generated `.python-version` records the exact Python interpreter that ran
+Copier. `uv` uses this file automatically, and template updates preserve it.
+
 ## Run local QA before pushing
 
 ```bash

--- a/python_package_copier_template/extensions.py
+++ b/python_package_copier_template/extensions.py
@@ -1,5 +1,6 @@
 """Jinja extensions and filters used while rendering the template."""
 
+import platform
 import re
 import shutil
 import subprocess
@@ -169,3 +170,12 @@ class CurrentYearExtension(Extension):
         """Register the current year in a Jinja environment."""
         super().__init__(environment)
         cast("dict[str, object]", environment.globals)["current_year"] = datetime.now(tz=UTC).year
+
+
+class PythonVersionExtension(Extension):
+    """Expose the running Python version to templates."""
+
+    def __init__(self, environment: Environment) -> None:
+        """Register the running Python version in a Jinja environment."""
+        super().__init__(environment)
+        cast("dict[str, object]", environment.globals)["python_version"] = platform.python_version()

--- a/python_package_copier_template/extensions.py
+++ b/python_package_copier_template/extensions.py
@@ -4,6 +4,7 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import unicodedata
 import urllib.error
 import urllib.request
@@ -19,6 +20,17 @@ from jinja2.ext import Extension
 
 _UPDATE_MODE: ContextVar[bool] = ContextVar("copier_template_update_mode", default=False)
 MAX_PYPI_SUFFIX = 50
+MIN_PROJECT_PYTHON = (3, 12)
+
+
+class UnsupportedPythonError(RuntimeError):
+    """Raised when Copier runs below the generated project's Python minimum."""
+
+    def __init__(self, minimum: str, running: str) -> None:
+        """Describe the required and running Python versions."""
+        super().__init__(
+            f"Python {minimum} or newer is required to generate a project; Copier is running on Python {running}."
+        )
 
 
 @contextmanager
@@ -178,4 +190,8 @@ class PythonVersionExtension(Extension):
     def __init__(self, environment: Environment) -> None:
         """Register the running Python version in a Jinja environment."""
         super().__init__(environment)
+        running_python = (sys.version_info.major, sys.version_info.minor)
+        if running_python < MIN_PROJECT_PYTHON:
+            minimum = ".".join(str(part) for part in MIN_PROJECT_PYTHON)
+            raise UnsupportedPythonError(minimum, platform.python_version())
         cast("dict[str, object]", environment.globals)["python_version"] = platform.python_version()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,6 +34,7 @@ def render_from_clean_template(tmp_path: Path, monkeypatch) -> tuple[Path, Path]
     template_src = Path(__file__).resolve().parent.parent
     clean_template = tmp_path / "template-src"
     subprocess.run(["git", "clone", str(template_src), str(clean_template)], check=True)
+    subprocess.run(["git", "-C", str(clean_template), "tag", "999.0.0"], check=True)
     monkeypatch.setattr(
         cli,
         "resolve_template_target",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,10 @@ import urllib.error
 from email.message import Message
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from jinja2 import Environment
 
 from python_package_copier_template import cli, extensions
 
@@ -34,7 +38,7 @@ def render_from_clean_template(tmp_path: Path, monkeypatch) -> tuple[Path, Path]
     template_src = Path(__file__).resolve().parent.parent
     clean_template = tmp_path / "template-src"
     subprocess.run(["git", "clone", str(template_src), str(clean_template)], check=True)
-    subprocess.run(["git", "-C", str(clean_template), "tag", "999.0.0"], check=True)
+    subprocess.run(["git", "-C", str(clean_template), "tag", "--force", "999.0.0"], check=True)
     monkeypatch.setattr(
         cli,
         "resolve_template_target",
@@ -96,6 +100,15 @@ def test_generated_project_files_do_not_keep_jinja_markers(tmp_path: Path, monke
         assert "{{" not in text
         assert "{%" not in text
         assert "%}" not in text
+
+
+def test_python_version_extension_rejects_unsupported_python(monkeypatch) -> None:
+    version_info = SimpleNamespace(major=3, minor=11)
+    monkeypatch.setattr(extensions, "sys", SimpleNamespace(version_info=version_info))
+    monkeypatch.setattr(extensions.platform, "python_version", lambda: "3.11.9")
+
+    with pytest.raises(RuntimeError, match=r"Python 3\.12 or newer.*Python 3\.11\.9"):
+        extensions.PythonVersionExtension(Environment(autoescape=True))
 
 
 def test_ruff_rules_include_defaults_and_requested_families() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import subprocess
 import tomllib
 import urllib.error
@@ -88,6 +89,7 @@ def test_cli_copy_and_update(tmp_path: Path, monkeypatch) -> None:
 def test_generated_project_files_do_not_keep_jinja_markers(tmp_path: Path, monkeypatch) -> None:
     dest, _ = render_from_clean_template(tmp_path, monkeypatch)
 
+    assert (dest / ".python-version").read_text(encoding="utf-8").strip() == platform.python_version()
     for relative_path in ("README.md", "pyproject.toml", "docs/index.md"):
         text = (dest / relative_path).read_text(encoding="utf-8")
         assert "{{" not in text
@@ -117,8 +119,10 @@ def test_update_preserves_existing_docs_and_adds_new_pages(tmp_path: Path, monke
 
     readme = dest / "README.md"
     configuration = dest / "docs/configuration.md"
+    python_version = dest / ".python-version"
     readme.write_text("# Custom project\n", encoding="utf-8")
     configuration.write_text("# Custom configuration\n", encoding="utf-8")
+    python_version.write_text("3.12.9\n", encoding="utf-8")
     subprocess.run(["git", "init", "-b", "main"], cwd=dest, check=True, env=env)
     subprocess.run(["git", "add", "."], cwd=dest, check=True, env=env)
     subprocess.run(["git", "commit", "-m", "customize docs"], cwd=dest, check=True, env=env)
@@ -144,6 +148,7 @@ def test_update_preserves_existing_docs_and_adds_new_pages(tmp_path: Path, monke
 
     assert readme.read_text(encoding="utf-8") == "# Custom project\n"
     assert configuration.read_text(encoding="utf-8") == "# Custom configuration\n"
+    assert python_version.read_text(encoding="utf-8") == "3.12.9\n"
     assert (dest / "docs/new_guide.md").read_text(encoding="utf-8") == "# New guide\n"
 
 


### PR DESCRIPTION
## Summary

- render `.python-version` with the exact Python interpreter running Copier
- support both direct Copier usage and the packaged CLI through a Jinja extension
- preserve an existing pin during later template updates
- remove the fixed `uv python pin 3.14` setup task
- document the generated pin in the project development guide
- make render tests exercise the current template revision and verify both creation and preservation

## Behavior

Running the template with Python `3.14.4` creates:

```text
3.14.4
```

Copier adds the file when it is absent, including on adoption by an existing
project, but `_skip_if_exists` prevents later updates from changing the project's
chosen interpreter.

## Verification

- `uv run ruff check .`
- `uv run ty check`
- `uv run pytest -q`
- `uv run --group docs sphinx-build docs docs/_build/html -b html -W`
- direct Copier render confirmed the generated pin matches `platform.python_version()`
