### PR TITLE
prek: builtin repo, more hooks, auto-fix

### DIFF
--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -6,7 +6,6 @@ hooks = [
   { id = "check-case-conflict" },
   { id = "check-illegal-windows-names" },
   { id = "end-of-file-fixer" },
-  { id = "fix-byte-order-marker" },
   { id = "check-json" },
   { id = "check-yaml" },
   { id = "check-toml" },
@@ -19,13 +18,7 @@ hooks = [
   { id = "detect-private-key" },
   { id = "check-executables-have-shebangs" },
   { id = "check-shebang-scripts-are-executable" },
-]
-
-[[repos]]
-repo = "https://github.com/pre-commit/pre-commit-hooks"
-rev = "v6.0.0"
-hooks = [
-  { id = "check-ast" },
+  { id = "no-commit-to-branch", args = ["--branch", "main"] },
 ]
 
 [[repos]]
@@ -35,7 +28,7 @@ repo = "local"
 id = "ruff-check"
 name = "ruff check"
 language = "system"
-entry = "uv run --only-group lint ruff check --fix"
+entry = "uv run ruff check --fix"
 pass_filenames = false
 always_run = true
 
@@ -43,7 +36,7 @@ always_run = true
 id = "ruff-format"
 name = "ruff format"
 language = "system"
-entry = "uv run --only-group lint ruff format"
+entry = "uv run ruff format"
 pass_filenames = false
 always_run = true
 
@@ -51,6 +44,6 @@ always_run = true
 id = "ty-check"
 name = "ty check"
 language = "system"
-entry = "uv run --group qa ty check"
+entry = "uv run ty check"
 pass_filenames = false
 always_run = true

--- a/project/prek.toml.jinja
+++ b/project/prek.toml.jinja
@@ -1,21 +1,31 @@
 [[repos]]
-repo = "https://github.com/pre-commit/pre-commit-hooks"
-rev = "v6.0.0"
+repo = "builtin"
 hooks = [
-  { id = "check-ast" },
   { id = "trailing-whitespace" },
   { id = "check-added-large-files" },
   { id = "check-case-conflict" },
+  { id = "check-illegal-windows-names" },
   { id = "end-of-file-fixer" },
+  { id = "fix-byte-order-marker" },
   { id = "check-json" },
   { id = "check-yaml" },
   { id = "check-toml" },
   { id = "check-xml" },
+  { id = "check-vcs-permalinks" },
   { id = "mixed-line-ending" },
   { id = "check-symlinks" },
+  { id = "destroyed-symlinks" },
   { id = "check-merge-conflict" },
   { id = "detect-private-key" },
   { id = "check-executables-have-shebangs" },
+  { id = "check-shebang-scripts-are-executable" },
+]
+
+[[repos]]
+repo = "https://github.com/pre-commit/pre-commit-hooks"
+rev = "v6.0.0"
+hooks = [
+  { id = "check-ast" },
 ]
 
 [[repos]]
@@ -25,7 +35,7 @@ repo = "local"
 id = "ruff-check"
 name = "ruff check"
 language = "system"
-entry = "uv run --only-group lint ruff check"
+entry = "uv run --only-group lint ruff check --fix"
 pass_filenames = false
 always_run = true
 
@@ -33,7 +43,7 @@ always_run = true
 id = "ruff-format"
 name = "ruff format"
 language = "system"
-entry = "uv run --only-group lint ruff format --check"
+entry = "uv run --only-group lint ruff format"
 pass_filenames = false
 always_run = true
 


### PR DESCRIPTION
## Summary
- Switch the `pre-commit-hooks` repo entries to prek's explicit `repo = "builtin"` mode where supported (no clone/network/env setup, instant startup); `check-ast` stays on the upstream repo since it isn't offered as a builtin hook.
- Enable a few more builtin hooks that were available but unused: `check-illegal-windows-names`, `fix-byte-order-marker`, `check-vcs-permalinks`, `destroyed-symlinks`, `check-shebang-scripts-are-executable`.
- Make `ruff-check` run with `--fix` and `ruff-format` without `--check`, so `prek run` auto-fixes safe lint issues and reformats files instead of just failing on them.

Closes #88, #90. For #89 ("enable more prek rules") I picked a reasonable set of additional builtin hooks relevant to a Python package repo — the issue had no body/checklist, so please confirm this covers what you had in mind or point me at specific rules to add/drop.

## Test plan
- [x] Generated a project from this branch with `copier copy . /tmp/prek-test --defaults --trust --vcs-ref HEAD`
- [x] `uv sync && prek run --all-files` on the generated project — all hooks pass
- [x] Introduced an unused import and a formatting issue, confirmed `ruff-check`/`ruff-format` auto-fix them in place
- [x] `uv run pytest -q` on the template repo itself — 13 passed