### PR TITLE
fix: don't run docs-publish on release events

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,7 +73,7 @@ jobs:
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'release' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     environment:
       name: ${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}
       url: ${{ steps.preview_url.outputs.url }}

--- a/project/.github/workflows/cd.yml.jinja
+++ b/project/.github/workflows/cd.yml.jinja
@@ -68,7 +68,7 @@ jobs:
   docs-publish:
     name: Publish documentation to GitHub Pages
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'release' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     environment:
       name: {% raw %}${{ github.event_name == 'pull_request' && 'github-pages-preview' || 'github-pages' }}{% endraw %}
       url: {% raw %}${{ steps.preview_url.outputs.url }}{% endraw %}


### PR DESCRIPTION
## Summary
- `docs-publish`'s `if:` only excluded external pull requests, so it still ran on `release` events. Actions checks out the release tag for those, and repositories that restrict the `github-pages` environment to `main` reject the deployment (`Tag "0.3.0" is not allowed to deploy to github-pages due to environment protection rules.`), as hit in `mgaitan/richterm` after updating to template 0.6.0.
- Documentation is already published by the `push` trigger when `docs/`, `README.md`, `CONTRIBUTING.md`, or the workflow itself change, so `release` events only need to run `pypi-publish`.
- Applied the fix to both the template (`project/.github/workflows/cd.yml.jinja`) and this repo's own `cd.yml`, since it's generated from itself and has the same bug.

Fixes #87. Matches the fix already validated downstream in mgaitan/richterm#12.

## Test plan
- [x] Generated a project from this branch and confirmed the rendered `cd.yml` has the corrected `if:` condition
- [x] `uv run pytest -q` — 13 passed
- [ ] Confirm on next release that `docs-publish` is skipped and `pypi-publish` still runs