### PR TITLE
release: strip maintainer attribution from auto-generated notes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,10 @@ release: ## Create a GitHub release for the current version
 	@version=$$(uv version --short); \
 	git commit -am "Bump $$version"; \
 	git push origin main; \
-	gh release create "$$version" --generate-notes
+	owner=$$(gh repo view --json owner -q .owner.login); \
+	gh api repos/{owner}/{repo}/releases/generate-notes -f tag_name="$$version" --jq .body \
+		| sed "s/ by @$$owner\$$//g; s/ by @$$owner / /g" \
+		| gh release create "$$version" --notes-file -
 
 smoke: ## Generate a project from template defaults and run generated QA
 	@tmp_dir=$$(mktemp -d); \

--- a/project/Makefile.jinja
+++ b/project/Makefile.jinja
@@ -33,7 +33,10 @@ release: ## Create a GitHub release for the current version
 	@version=$$(uv version --short); \
 	git commit -am "Bump $$version"; \
 	git push origin main; \
-	gh release create "$$version" --generate-notes
+	owner=$$(gh repo view --json owner -q .owner.login); \
+	gh api repos/{owner}/{repo}/releases/generate-notes -f tag_name="$$version" --jq .body \
+		| sed "s/ by @$$owner\$$//g; s/ by @$$owner / /g" \
+		| gh release create "$$version" --notes-file -
 
 .PHONY: docs docs-html docs-epub docs-open html epub open
 


### PR DESCRIPTION
## Summary
- `gh release create --generate-notes` attributes every merged PR with "by @author in #N", which is verbose when the author is the project maintainer creating the release themself.
- Switched to fetching notes via `gh api repos/{owner}/{repo}/releases/generate-notes` (same generator GitHub uses), then strip the repo owner's own "by @<login>" attribution with `sed` before passing the body to `gh release create --notes-file -`. Other contributors keep their "by @author" credit.
- Applied to both `Makefile` (this repo, self-generated) and `project/Makefile.jinja` (the template).

Fixes #86

## Test plan
- [x] `sed` logic verified against a sample notes body — maintainer's "by @mgaitan" removed, "by @someoneelse" preserved
- [x] `make -n release` on both this repo and a freshly generated project — commands expand correctly
- [x] `uv run pytest -q` on the template repo and a generated project — all green
- [ ] Confirm on the next real release that notes read correctly and other contributors are still credited